### PR TITLE
[#27] Feature: OpenAiClient 모듈 구현

### DIFF
--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/OpenAiClientApplication.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/OpenAiClientApplication.java
@@ -2,8 +2,10 @@ package org.openaiclient;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class OpenAiClientApplication {
 
 	public static void main(String[] args) {

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
@@ -1,0 +1,56 @@
+package org.openaiclient.client;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.openaiclient.client.dto.request.ChatCompletionRequest;
+import org.openaiclient.client.dto.response.ChatCompletionResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class OpenAiClient {
+
+	private final RestClient openAiClient;
+
+	public OpenAiClient(
+		@Value("${client.openai.url}") String url,
+		@Value("${client.openai.key}") String key
+	) {
+		this.openAiClient = RestClient.builder()
+			.baseUrl(url)
+			.defaultHeader("Authorization", "Bearer " + key)
+			.defaultHeader("Content-Type", "application/json")
+			.build();
+	}
+
+	public ChatCompletionResponse getChatCompletion(ChatCompletionRequest chatCompletionRequest) {
+		return openAiClient.post()
+			.body(chatCompletionRequest)
+			.retrieve()
+			.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+				throw new RuntimeException("Client error: " + res.getStatusCode());
+			})
+			.onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+				throw new RuntimeException("Server error: " + res.getStatusCode());
+			})
+			.body(ChatCompletionResponse.class);
+	}
+
+	@Async
+	public CompletableFuture<ChatCompletionResponse> getChatCompletionAsync(
+		ChatCompletionRequest chatCompletionRequest) {
+		return CompletableFuture.supplyAsync(() -> openAiClient.post()
+			.body(chatCompletionRequest)
+			.retrieve()
+			.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+				throw new RuntimeException("Client error: " + res.getStatusCode());
+			})
+			.onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+				throw new RuntimeException("Server error: " + res.getStatusCode());
+			})
+			.body(ChatCompletionResponse.class));
+	}
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
@@ -41,16 +41,18 @@ public class OpenAiClient {
 
 	@Async
 	public CompletableFuture<ChatCompletionResponse> getChatCompletionAsync(
-		ChatCompletionRequest chatCompletionRequest) {
-		return CompletableFuture.supplyAsync(() -> openAiClient.post()
-			.body(chatCompletionRequest)
-			.retrieve()
-			.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
-				throw new RuntimeException("Client error: " + res.getStatusCode());
-			})
-			.onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
-				throw new RuntimeException("Server error: " + res.getStatusCode());
-			})
-			.body(ChatCompletionResponse.class));
+		ChatCompletionRequest chatCompletionRequest
+	) {
+		return CompletableFuture.completedFuture(
+			openAiClient.post()
+				.body(chatCompletionRequest)
+				.retrieve()
+				.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+					throw new RuntimeException("Client error: " + res.getStatusCode());
+				})
+				.onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+					throw new RuntimeException("Server error: " + res.getStatusCode());
+				})
+				.body(ChatCompletionResponse.class));
 	}
 }

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
@@ -43,16 +43,6 @@ public class OpenAiClient {
 	public CompletableFuture<ChatCompletionResponse> getChatCompletionAsync(
 		ChatCompletionRequest chatCompletionRequest
 	) {
-		return CompletableFuture.completedFuture(
-			openAiClient.post()
-				.body(chatCompletionRequest)
-				.retrieve()
-				.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
-					throw new RuntimeException("Client error: " + res.getStatusCode());
-				})
-				.onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
-					throw new RuntimeException("Server error: " + res.getStatusCode());
-				})
-				.body(ChatCompletionResponse.class));
+		return CompletableFuture.completedFuture(getChatCompletion(chatCompletionRequest));
 	}
 }

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/ChatCompletionRequest.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/ChatCompletionRequest.java
@@ -1,0 +1,22 @@
+package org.openaiclient.client.dto.request;
+
+import java.util.List;
+
+import org.openaiclient.client.dto.request.type.RequestMessage;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatCompletionRequest {
+
+	private String model;
+
+	private List<RequestMessage> messages;
+
+	public ChatCompletionRequest(String model, List<RequestMessage> messages) {
+		this.model = model;
+		this.messages = messages;
+	}
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/ChatCompletionRequest.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/ChatCompletionRequest.java
@@ -3,6 +3,9 @@ package org.openaiclient.client.dto.request;
 import java.util.List;
 
 import org.openaiclient.client.dto.request.type.RequestMessage;
+import org.openaiclient.client.dto.request.type.ResponseFormat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -15,8 +18,12 @@ public class ChatCompletionRequest {
 
 	private List<RequestMessage> messages;
 
-	public ChatCompletionRequest(String model, List<RequestMessage> messages) {
+	@JsonProperty("response_format")
+	private ResponseFormat responseFormat;
+
+	public ChatCompletionRequest(String model, List<RequestMessage> messages, ResponseFormat responseFormat) {
 		this.model = model;
 		this.messages = messages;
+		this.responseFormat = responseFormat;
 	}
 }

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/ChatCompletionRequest.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/ChatCompletionRequest.java
@@ -8,10 +8,8 @@ import org.openaiclient.client.dto.request.type.ResponseFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class ChatCompletionRequest {
 
 	private String model;
@@ -21,7 +19,8 @@ public class ChatCompletionRequest {
 	@JsonProperty("response_format")
 	private ResponseFormat responseFormat;
 
-	public ChatCompletionRequest(String model, List<RequestMessage> messages, ResponseFormat responseFormat) {
+	public ChatCompletionRequest(String model, List<RequestMessage> messages,
+		ResponseFormat responseFormat) {
 		this.model = model;
 		this.messages = messages;
 		this.responseFormat = responseFormat;

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/RequestMessage.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/RequestMessage.java
@@ -1,10 +1,8 @@
 package org.openaiclient.client.dto.request.type;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class RequestMessage {
 
 	private String role;

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/RequestMessage.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/RequestMessage.java
@@ -1,0 +1,18 @@
+package org.openaiclient.client.dto.request.type;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RequestMessage {
+
+	private String role;
+
+	private String content;
+
+	public RequestMessage(String role, String content) {
+		this.role = role;
+		this.content = content;
+	}
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/ResponseFormat.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/ResponseFormat.java
@@ -2,13 +2,13 @@ package org.openaiclient.client.dto.request.type;
 
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResponseFormat {
 
 	private String type;

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/ResponseFormat.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/request/type/ResponseFormat.java
@@ -1,0 +1,23 @@
+package org.openaiclient.client.dto.request.type;
+
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResponseFormat {
+
+	private String type;
+
+	@JsonProperty("json_schema")
+	private Map<String, Object> jsonSchema;
+
+	public ResponseFormat(String type, Map<String, Object> jsonSchema) {
+		this.type = type;
+		this.jsonSchema = jsonSchema;
+	}
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/ChatCompletionResponse.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/ChatCompletionResponse.java
@@ -9,10 +9,8 @@ import org.springframework.lang.Nullable;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class ChatCompletionResponse {
 
 	private String id;

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/ChatCompletionResponse.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/ChatCompletionResponse.java
@@ -1,0 +1,36 @@
+package org.openaiclient.client.dto.response;
+
+import java.util.List;
+
+import org.openaiclient.client.dto.response.type.Choice;
+import org.openaiclient.client.dto.response.type.Usage;
+import org.springframework.lang.Nullable;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatCompletionResponse {
+
+	private String id;
+
+	private List<Choice> choices;
+
+	private Integer created;
+
+	private String model;
+
+	@Nullable
+	@JsonProperty("service_tier")
+	private String serviceTier;
+
+	@JsonProperty("system_fingerprint")
+	private String systemFingerprint;
+
+	private String object;
+
+	private Usage usage;
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Choice.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Choice.java
@@ -3,10 +3,8 @@ package org.openaiclient.client.dto.response.type;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class Choice {
 
 	private Integer index;

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Choice.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Choice.java
@@ -1,0 +1,18 @@
+package org.openaiclient.client.dto.response.type;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Choice {
+
+	private Integer index;
+
+	private ResponseMessage message;
+
+	@JsonProperty("finish_reason")
+	private String finishReason;
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/ResponseMessage.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/ResponseMessage.java
@@ -1,0 +1,15 @@
+package org.openaiclient.client.dto.response.type;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ResponseMessage {
+
+	private String role;
+
+	private String content;
+
+	private String refusal;
+}

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Usage.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Usage.java
@@ -3,10 +3,8 @@ package org.openaiclient.client.dto.response.type;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class Usage {
 
 	@JsonProperty("prompt_tokens")

--- a/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Usage.java
+++ b/inner-system/open-ai-client/src/main/java/org/openaiclient/client/dto/response/type/Usage.java
@@ -1,0 +1,20 @@
+package org.openaiclient.client.dto.response.type;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Usage {
+
+	@JsonProperty("prompt_tokens")
+	private Integer promptTokens;
+
+	@JsonProperty("completion_tokens")
+	private Integer completionTokens;
+
+	@JsonProperty("total_tokens")
+	private Integer totalTokens;
+}

--- a/inner-system/open-ai-client/src/main/resources/application.properties
+++ b/inner-system/open-ai-client/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=open-ai-client

--- a/inner-system/open-ai-client/src/main/resources/application.yml
+++ b/inner-system/open-ai-client/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+    application:
+        name: open-ai-client
+
+client:
+    openai:
+        url: https://api.openai.com/v1/chat/completions
+        key: ${OPENAI_API_KEY}
+        model: gpt-4o-mini

--- a/inner-system/open-ai-client/src/test/java/org/openaiclient/client/OpenAiClientTest.java
+++ b/inner-system/open-ai-client/src/test/java/org/openaiclient/client/OpenAiClientTest.java
@@ -15,6 +15,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @SpringBootTest
 @ExtendWith(SpringExtension.class)
 class OpenAiClientTest {
@@ -23,14 +26,14 @@ class OpenAiClientTest {
 	OpenAiClient openAiClient;
 
 	@Test
-	void getChatCompletionTest() {
+	void getChatCompletionTest() throws JsonProcessingException {
 		// Given
 		String model = "gpt-4o-mini";
 
 		ArrayList<RequestMessage> messages = new ArrayList<>();
 		messages.add(new RequestMessage("user", "내일 점심 메뉴를 추천해줘"));
 		messages.add(new RequestMessage("system",
-			"user의 질문에 대해 2-3문장 정도로 content를 답변해주고, content에 대한 핵심 내용인 summary를 명사형으로 함께 답변해줘. JSON 형태로 답변해야 해."));
+			"user의 질문에 대해 2-3문장 정도로 content를 답변해주고, content에 대한 핵심 주제 요약인 summary를 명사형으로 함께 답변해줘. JSON 형태로 답변해야 해."));
 		ResponseFormat responseFormat = new ResponseFormat("json_schema", Map.of(
 			"name", "test_response",
 			"strict", true,
@@ -53,24 +56,34 @@ class OpenAiClientTest {
 
 		// When
 		ChatCompletionResponse result = openAiClient.getChatCompletion(
-			new ChatCompletionRequest(model, messages, responseFormat));
+			new ChatCompletionRequest(model, messages, responseFormat)
+		);
 
 		// Then
 		System.out.println(result.getChoices().get(0).getMessage().getRole());
 		System.out.println(result.getChoices().get(0).getMessage().getContent());
+		ObjectMapper objectMapper = new ObjectMapper();
+		TestResponse content = objectMapper.readValue(
+			result.getChoices().get(0).getMessage().getContent(),
+			TestResponse.class
+		);
+		System.out.println(content.getSummary());
+		System.out.println(content.getContent());
 		Assertions.assertAll(
-			() -> Assertions.assertFalse(result.getChoices().isEmpty())
+			() -> Assertions.assertFalse(result.getChoices().isEmpty()),
+			() -> Assertions.assertInstanceOf(TestResponse.class, content)
 		);
 	}
 
 	@Test
-	void getChatCompletionAsyncTest() {
+	void getChatCompletionAsyncTest() throws JsonProcessingException {
 		// Given
 		String model = "gpt-4o-mini";
+
 		ArrayList<RequestMessage> messages = new ArrayList<>();
 		messages.add(new RequestMessage("user", "내일 점심 메뉴를 추천해줘"));
 		messages.add(new RequestMessage("system",
-			"user의 질문에 대해 2-3문장 정도로 content를 답변해주고, content에 대한 핵심 내용인 summary를 명사형으로 함께 답변해줘. JSON 형태로 답변해야 해."));
+			"user의 질문에 대해 2-3문장 정도로 content를 답변해주고, content에 대한 핵심 주제 요약인 summary를 명사형으로 함께 답변해줘. JSON 형태로 답변해야 해."));
 		ResponseFormat responseFormat = new ResponseFormat("json_schema", Map.of(
 			"name", "test_response",
 			"strict", true,
@@ -93,13 +106,22 @@ class OpenAiClientTest {
 
 		// When
 		ChatCompletionResponse result = openAiClient.getChatCompletionAsync(
-			new ChatCompletionRequest(model, messages, responseFormat)).join();
+			new ChatCompletionRequest(model, messages, responseFormat)
+		).join();
 
 		// Then
 		System.out.println(result.getChoices().get(0).getMessage().getRole());
 		System.out.println(result.getChoices().get(0).getMessage().getContent());
+		ObjectMapper objectMapper = new ObjectMapper();
+		TestResponse content = objectMapper.readValue(
+			result.getChoices().get(0).getMessage().getContent(),
+			TestResponse.class
+		);
+		System.out.println(content.getSummary());
+		System.out.println(content.getContent());
 		Assertions.assertAll(
-			() -> Assertions.assertFalse(result.getChoices().isEmpty())
+			() -> Assertions.assertFalse(result.getChoices().isEmpty()),
+			() -> Assertions.assertInstanceOf(TestResponse.class, content)
 		);
 	}
 }

--- a/inner-system/open-ai-client/src/test/java/org/openaiclient/client/OpenAiClientTest.java
+++ b/inner-system/open-ai-client/src/test/java/org/openaiclient/client/OpenAiClientTest.java
@@ -1,12 +1,15 @@
 package org.openaiclient.client;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.openaiclient.client.dto.request.ChatCompletionRequest;
 import org.openaiclient.client.dto.request.type.RequestMessage;
+import org.openaiclient.client.dto.request.type.ResponseFormat;
 import org.openaiclient.client.dto.response.ChatCompletionResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,13 +26,34 @@ class OpenAiClientTest {
 	void getChatCompletionTest() {
 		// Given
 		String model = "gpt-4o-mini";
-		RequestMessage message = new RequestMessage("user", "내일 점심 메뉴를 추천해줘");
+
 		ArrayList<RequestMessage> messages = new ArrayList<>();
-		messages.add(message);
+		messages.add(new RequestMessage("user", "내일 점심 메뉴를 추천해줘"));
+		messages.add(new RequestMessage("system",
+			"user의 질문에 대해 2-3문장 정도로 content를 답변해주고, content에 대한 핵심 내용인 summary를 명사형으로 함께 답변해줘. JSON 형태로 답변해야 해."));
+		ResponseFormat responseFormat = new ResponseFormat("json_schema", Map.of(
+			"name", "test_response",
+			"strict", true,
+			"schema", Map.of(
+				"type", "object",
+				"properties", Map.of(
+					"summary", Map.of(
+						"type", "string",
+						"description", "summary of main content"
+					),
+					"content", Map.of(
+						"type", "string",
+						"description", "main content"
+					)
+				),
+				"additionalProperties", false,
+				"required", List.of("summary", "content")
+			)
+		));
 
 		// When
 		ChatCompletionResponse result = openAiClient.getChatCompletion(
-			new ChatCompletionRequest(model, messages));
+			new ChatCompletionRequest(model, messages, responseFormat));
 
 		// Then
 		System.out.println(result.getChoices().get(0).getMessage().getRole());
@@ -43,13 +67,33 @@ class OpenAiClientTest {
 	void getChatCompletionAsyncTest() {
 		// Given
 		String model = "gpt-4o-mini";
-		RequestMessage message = new RequestMessage("user", "내일 점심 메뉴를 추천해줘");
 		ArrayList<RequestMessage> messages = new ArrayList<>();
-		messages.add(message);
+		messages.add(new RequestMessage("user", "내일 점심 메뉴를 추천해줘"));
+		messages.add(new RequestMessage("system",
+			"user의 질문에 대해 2-3문장 정도로 content를 답변해주고, content에 대한 핵심 내용인 summary를 명사형으로 함께 답변해줘. JSON 형태로 답변해야 해."));
+		ResponseFormat responseFormat = new ResponseFormat("json_schema", Map.of(
+			"name", "test_response",
+			"strict", true,
+			"schema", Map.of(
+				"type", "object",
+				"properties", Map.of(
+					"summary", Map.of(
+						"type", "string",
+						"description", "summary of main content"
+					),
+					"content", Map.of(
+						"type", "string",
+						"description", "main content"
+					)
+				),
+				"additionalProperties", false,
+				"required", List.of("summary", "content")
+			)
+		));
 
 		// When
 		ChatCompletionResponse result = openAiClient.getChatCompletionAsync(
-			new ChatCompletionRequest(model, messages)).join();
+			new ChatCompletionRequest(model, messages, responseFormat)).join();
 
 		// Then
 		System.out.println(result.getChoices().get(0).getMessage().getRole());

--- a/inner-system/open-ai-client/src/test/java/org/openaiclient/client/OpenAiClientTest.java
+++ b/inner-system/open-ai-client/src/test/java/org/openaiclient/client/OpenAiClientTest.java
@@ -1,0 +1,61 @@
+package org.openaiclient.client;
+
+import java.util.ArrayList;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openaiclient.client.dto.request.ChatCompletionRequest;
+import org.openaiclient.client.dto.request.type.RequestMessage;
+import org.openaiclient.client.dto.response.ChatCompletionResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@SpringBootTest
+@ExtendWith(SpringExtension.class)
+class OpenAiClientTest {
+
+	@Autowired
+	OpenAiClient openAiClient;
+
+	@Test
+	void getChatCompletionTest() {
+		// Given
+		String model = "gpt-4o-mini";
+		RequestMessage message = new RequestMessage("user", "내일 점심 메뉴를 추천해줘");
+		ArrayList<RequestMessage> messages = new ArrayList<>();
+		messages.add(message);
+
+		// When
+		ChatCompletionResponse result = openAiClient.getChatCompletion(
+			new ChatCompletionRequest(model, messages));
+
+		// Then
+		System.out.println(result.getChoices().get(0).getMessage().getRole());
+		System.out.println(result.getChoices().get(0).getMessage().getContent());
+		Assertions.assertAll(
+			() -> Assertions.assertFalse(result.getChoices().isEmpty())
+		);
+	}
+
+	@Test
+	void getChatCompletionAsyncTest() {
+		// Given
+		String model = "gpt-4o-mini";
+		RequestMessage message = new RequestMessage("user", "내일 점심 메뉴를 추천해줘");
+		ArrayList<RequestMessage> messages = new ArrayList<>();
+		messages.add(message);
+
+		// When
+		ChatCompletionResponse result = openAiClient.getChatCompletionAsync(
+			new ChatCompletionRequest(model, messages)).join();
+
+		// Then
+		System.out.println(result.getChoices().get(0).getMessage().getRole());
+		System.out.println(result.getChoices().get(0).getMessage().getContent());
+		Assertions.assertAll(
+			() -> Assertions.assertFalse(result.getChoices().isEmpty())
+		);
+	}
+}

--- a/inner-system/open-ai-client/src/test/java/org/openaiclient/client/TestResponse.java
+++ b/inner-system/open-ai-client/src/test/java/org/openaiclient/client/TestResponse.java
@@ -1,0 +1,19 @@
+package org.openaiclient.client;
+
+public class TestResponse {
+
+	private String content;
+
+	private String summary;
+
+	public TestResponse() {
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public String getSummary() {
+		return summary;
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #27 

## 📌 작업 내용 및 특이사항

### 1. OpenAiClient 구현
OpenAI API에 대한 요청을 처리하는 OpenAiClient 컴포넌트를 구현했습니다. 당장 사용할 ChatCompletion API에 대한 메서드만 구현했고, 동기/비동기 메서드를 각각 구현해두었습니다.
```java
@Component
public class OpenAiClient {

	private final RestClient openAiClient;

	public OpenAiClient(
		@Value("${client.openai.url}") String url,
		@Value("${client.openai.key}") String key
	) {
		// ...
	}

	public ChatCompletionResponse getChatCompletion(ChatCompletionRequest chatCompletionRequest) {
		// ...
	}

	@Async
	public CompletableFuture<ChatCompletionResponse> getChatCompletionAsync(
                ChatCompletionRequest chatCompletionRequest) {
                // ...
        }
```

### 2. ChatCompletion API 응답 포맷 설정
응답 포맷을 위해 json schema 사용 시, Map 타입으로 json schema를 요청 객체에 포함할 수 있게 구현했습니다.
그렇지만 이렇게 Map을 직접 작성하면 가독성이 많이 떨어지고 유지보수가 어려워서, json 파일을 따로 관리하고 이를 Map으로 변환하는 식으로 사용하는 쪽이 좋을 것 같습니다.
```java
ResponseFormat responseFormat = new ResponseFormat("json_schema", Map.of(
	"name", "test_response",
	"strict", true,
	"schema", Map.of(
		"type", "object",
		"properties", Map.of(
			"summary", Map.of(
				"type", "string",
				"description", "summary of main content"
			),
			"content", Map.of(
				"type", "string",
				"description", "main content"
			)
		),
		"additionalProperties", false,
		"required", List.of("summary", "content")
	)
));

ChatCompletionResponse result = openAiClient.getChatCompletion(
	new ChatCompletionRequest(model, messages, responseFormat));
```

## 🚀 리뷰 해줬으면 하는 부분
- feed-client모듈의 경우에는 의존하는 쪽에서 Client 컴포넌트가 아닌 Service 컴포넌트를 사용하게 되는데, 이번 openai-client 모듈의 경우 바로 Client 컴포넌트를 사용하게 되어서 사용에 약간 혼동이 생길 수도 있어 보이네요.. 어떻게 생각하시나요??


