### PR TITLE
[#32] MVP용 인증 구현 및 Oauth2 예외처리

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/global/config/WebSecurityConfig.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/config/WebSecurityConfig.java
@@ -6,6 +6,7 @@ import static org.springframework.security.config.Customizer.*;
 import org.mainapplication.global.constants.UrlConstants;
 import org.mainapplication.global.constants.WebSecurityURI;
 import org.mainapplication.global.filter.JwtAuthenticationFilter;
+import org.mainapplication.global.filter.TestAuthenticationFilter;
 import org.mainapplication.global.oauth2.handler.CustomOAuth2FailureHandler;
 import org.mainapplication.global.oauth2.handler.CustomOAuth2SuccessHandler;
 import org.mainapplication.global.oauth2.service.CustomOauth2UserService;
@@ -31,10 +32,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @EnableWebSecurity
 public class WebSecurityConfig {
-	private final JwtAuthenticationFilter jwtAuthenticaltionFilter;
+	// private final JwtAuthenticationFilter jwtAuthenticaltionFilter;
 	private final CustomOauth2UserService customOauth2UserService;
 	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
+	private final TestAuthenticationFilter testAuthenticationFilter;
 
 	private void defaultBasicFilterChain(HttpSecurity http) throws Exception {
 		http.httpBasic(AbstractHttpConfigurer::disable)
@@ -72,7 +74,8 @@ public class WebSecurityConfig {
 				exceptionHandling
 					.authenticationEntryPoint(customAuthenticationEntryPoint())
 			)
-			.addFilterBefore(jwtAuthenticaltionFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(testAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			// .addFilterBefore(jwtAuthenticaltionFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}

--- a/application/main-application/src/main/java/org/mainapplication/global/constants/WebSecurityURI.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/constants/WebSecurityURI.java
@@ -10,9 +10,7 @@ public final class WebSecurityURI {
 
 	public static final List<String> PUBLIC_URIS = List.of(
 		"/auth/login/oauth2/code/google",
-		"/swagger-ui/**",
-		"/v3/api-docs/**",
-		"/swagger-resources/**"
+		"/common/health/**"
 	);
 
 	public static final List<String> CORS_ALLOW_URIS =

--- a/application/main-application/src/main/java/org/mainapplication/global/constants/WebSecurityURI.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/constants/WebSecurityURI.java
@@ -10,7 +10,9 @@ public final class WebSecurityURI {
 
 	public static final List<String> PUBLIC_URIS = List.of(
 		"/auth/login/oauth2/code/google",
-		"/common/health/**"
+		"/swagger-ui/**",
+		"/v3/api-docs/**",
+		"/swagger-resources/**"
 	);
 
 	public static final List<String> CORS_ALLOW_URIS =

--- a/application/main-application/src/main/java/org/mainapplication/global/filter/TestAuthenticationFilter.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/filter/TestAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package org.mainapplication.global.filter;
+
+import java.io.IOException;
+
+import org.mainapplication.global.constants.WebSecurityURI;
+import org.mainapplication.global.util.JwtUtil;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class TestAuthenticationFilter extends OncePerRequestFilter {
+
+	private final JwtUtil jwtUtil;
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+
+		String userId = "1";
+		SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(userId));
+		filterChain.doFilter(request, response);
+	}
+
+	/**
+	 * 필터를 거치지 않는 URI를 설정
+	 * @return 필터링 여부
+	 */
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		// 정확히 매칭하도록 AntPathRequestMatcher를 제거하고 직접 비교
+		return WebSecurityURI.PUBLIC_URIS.stream()
+			.anyMatch(uri -> new AntPathRequestMatcher(uri).matches(request));
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/global/oauth2/handler/CustomOAuth2FailureHandler.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/oauth2/handler/CustomOAuth2FailureHandler.java
@@ -1,0 +1,24 @@
+package org.mainapplication.global.oauth2.handler;
+
+import java.io.IOException;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler {
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws
+		IOException {
+
+		// 실패 응답을 JSON으로 반환
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+		response.setContentType("application/json;charset=UTF-8");
+		response.getWriter().write("{\"error\": \"Authentication failed\", \"message\": \"" + exception.getMessage() + "\"}");
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/global/util/JwtUtil.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/util/JwtUtil.java
@@ -139,8 +139,8 @@ public class JwtUtil {
 		return authHeader.replace(HeaderConstants.TOKEN_PREFIX, "");
 	}
 
-	public Authentication getAuthentication(String memberId) {
+	public Authentication getAuthentication(String userId) {
 		// authorities는 지금 ROLE이 필요 없어서 null, credentials은 비밀번호가 들어가는데 jwt이므로 패스
-		return new UsernamePasswordAuthenticationToken(memberId, null, null);
+		return new UsernamePasswordAuthenticationToken(userId, null, null);
 	}
 }

--- a/application/main-application/src/main/resources/application-oauth.yml
+++ b/application/main-application/src/main/resources/application-oauth.yml
@@ -24,5 +24,5 @@ spring:
 jwt:
   access-token-key: ${ACCESS_JWT_KEY:}
   refresh-token-key: ${REFRESH_JWT_KEY:}
-  access-token-expiration: ${ACCESS_JWT_EXPIRATION:900000}  # 15분
+  access-token-expiration: ${ACCESS_JWT_EXPIRATION:900000 * 4 * 24 * 30}  # 15분
   refresh-token-expiration: ${REFRESH_JWT_EXPIRATION:604800000} # 7일


### PR DESCRIPTION
## 🌱 관련 이슈
- close #32 

## 📌 작업 내용 및 특이사항
- MVP 프론트 통신을 위해서 로그인 없이 진행할 수 있도록 oauth2, jwt 필터 검증 부분을 제외시킨 testAuthenticationFilter을 구현했습니다.
- testAuthentication 필터 구현 -> 토큰 검증 제거 & 무조건 필터 거치면 userId가 "1"인 사람으로 등록
- mock 유저는 1번째 사람으로 등록
- Oauth2 로그인 실패 시 예외 핸들러 설정 (CustomOAuth2FailureHandler)
- 인증이 필요한 경로로 접근 시 예외처리 ( customAuthenticationEntryPoint( ) )

- 기존에 사용하던 원래 필터는 주석처리 했습니다

## 🧐 고민한 점
- accessToken을 기존의 헤더에서 쿠키로 변경하려고 했었는데 프론트쪽에서 필터를 안거치는게 더 접근이 쉬울 것 같아서 토큰 유효검사를 안거치고 고정 유저로 로그인 되도록 수정했습니닷


## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


