### PR TITLE
[#46] WebSecurityConfig에서 JwtAuthenticationFilter 의존성 제거

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/global/config/WebSecurityConfig.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/config/WebSecurityConfig.java
@@ -5,7 +5,6 @@ import static org.springframework.security.config.Customizer.*;
 
 import org.mainapplication.global.constants.UrlConstants;
 import org.mainapplication.global.constants.WebSecurityURI;
-import org.mainapplication.global.filter.JwtAuthenticationFilter;
 import org.mainapplication.global.filter.TestAuthenticationFilter;
 import org.mainapplication.global.oauth2.handler.CustomAuthenticationEntryPoint;
 import org.mainapplication.global.oauth2.handler.CustomOAuth2FailureHandler;
@@ -19,14 +18,12 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
@@ -34,7 +31,7 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 public class WebSecurityConfig {
 
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
+	// private final JwtAuthenticationFilter jwtAuthenticationFilter;
 	private final CustomOauth2UserService customOauth2UserService;
 	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
 	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
@@ -78,7 +75,7 @@ public class WebSecurityConfig {
 					.authenticationEntryPoint(customAuthenticationEntryPoint.oAuth2EntryPoint())
 			)
 			.addFilterBefore(testAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-			// .addFilterBefore(jwtAuthenticaltionFilter, UsernamePasswordAuthenticationFilter.class);
+		// .addFilterBefore(jwtAuthenticaltionFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #46

## 📌 작업 내용 및 특이사항
- JwtAuthenticationFilter를 Bean으로 등록하는 부분이 비활성화되었는데, WebSecurityConfig에서 의존성 주입받는 부분이 남아있어 애플리케이션이 실행되지 않는 문제가 발생했습니다.
- WebSecurityConfig에서 해당 의존성 제거하였습니다. 추후 사용하게 될 컴포넌트라서, 당장은 주석처리만 해두었습니다.
```java
public class WebSecurityConfig {

	// private final JwtAuthenticationFilter jwtAuthenticationFilter;
	private final CustomOauth2UserService customOauth2UserService;
	private final CustomOAuth2SuccessHandler customOAuth2SuccessHandler;
	private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
```
