### PR TITLE
[#57] Feature: 게시물 추가 생성 API 구현

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -12,8 +12,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -26,11 +24,6 @@ public class PostController {
 	private final PostService postService;
 
 	@Operation(summary = "게시물 그룹 및 게시물 생성 API", description = "에이전트에 새 게시물 그룹을 추가하고 게시물을 생성합니다.")
-	@ApiResponses(value = {
-		@ApiResponse(responseCode = "201", description = "게시물 그룹 및 게시물 생성 성공"),
-		@ApiResponse(responseCode = "400", description = "잘못된 요청 형식"),
-		@ApiResponse(responseCode = "404", description = "에이전트 찾을 수 없음")
-	})
 	@PostMapping("/posts")
 	public ResponseEntity<CreatePostsResponse> createPosts(
 		@PathVariable Long agentId,
@@ -42,5 +35,15 @@ public class PostController {
 			case NEWS -> ResponseEntity.ok(postService.createPostsByNews(createPostsRequest, limit));
 			case IMAGE -> ResponseEntity.ok(postService.createPostsByImage(createPostsRequest, limit));
 		};
+	}
+
+	@Operation(summary = "게시물 추가 생성 API", description = "기존 게시물 그룹에 새 게시물을 추가합니다.")
+	@PostMapping("/{postGroupId}/posts")
+	public ResponseEntity<CreatePostsResponse> createAdditionalPosts(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@RequestParam(defaultValue = "5") Integer limit
+	) {
+		return ResponseEntity.ok(postService.createAdditionalPosts(postGroupId, limit));
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -20,6 +20,7 @@ import org.mainapplication.domain.post.exception.PostErrorCode;
 import org.mainapplication.domain.post.service.dto.SavePostGroupAndPostsDto;
 import org.mainapplication.domain.post.service.dto.SavePostGroupWithImagesAndPostsDto;
 import org.mainapplication.domain.post.service.dto.SavePostGroupWithRssCursorAndPostsDto;
+import org.mainapplication.domain.post.service.vo.GeneratePostsVo;
 import org.mainapplication.global.error.CustomException;
 import org.mainapplication.openai.contentformat.jsonschema.SummaryContentSchema;
 import org.mainapplication.openai.contentformat.response.SummaryContentFormat;
@@ -52,19 +53,11 @@ public class PostService {
 	private String openAiModel;
 
 	/**
-	 * 참고자료 없는 게시물 생성 메서드
+	 * 참고자료 없는 게시물 생성 및 저장 메서드
 	 */
 	public CreatePostsResponse createPostsWithoutRef(CreatePostsRequest request, Integer limit) {
-		// 프롬프트 생성: Instruction + 주제 Prompt
-		String instructionPrompt = createPostPrompt.getInstruction();
-		String topicPrompt = createPostPrompt.getBasicTopicPrompt(request);
-
 		// 게시물 생성
-		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(openAiModel,
-			summaryContentSchema.getResponseFormat(), limit, null)
-			.addDeveloperMessage(instructionPrompt)
-			.addUserTextMessage(topicPrompt);
-		ChatCompletionResponse result = generatePosts(chatCompletionRequest);
+		ChatCompletionResponse result = generatePostsWithoutRef(GeneratePostsVo.of(request, limit));
 
 		// PostGroup 엔티티 생성
 		PostGroup postGroup = PostGroup.createPostGroup(null, null, request.getTopic(), request.getPurpose(),
@@ -90,33 +83,17 @@ public class PostService {
 	}
 
 	/**
-	 * 뉴스 기사 기반 게시물 생성 메서드
+	 * 뉴스 기사 기반 게시물 생성 및 저장 메서드
 	 */
 	public CreatePostsResponse createPostsByNews(CreatePostsRequest request, Integer limit) {
 		// 피드 받아오기
 		RssFeed rssFeed = rssFeedRepository.findByCategory(request.getNewsCategory())
 			.orElseThrow(() -> new RssFeedNotFoundException("뉴스 카테고리를 찾을 수 없습니다."));
-		FeedPagingResult feedPagingResult = getNewsFeed(rssFeed, limit);
+		FeedPagingResult feedPagingResult = getPagedNews(rssFeed, null, limit);
 
-		// 프롬프트 생성
-		String instructionPrompt = createPostPrompt.getInstruction();
-		String topicPrompt = createPostPrompt.getBasicTopicPrompt(request);
-		List<String> refPrompts = feedPagingResult.getFeedItems().stream()
-			.map(news -> createPostPrompt.getNewsRefPrompt(news.getContentSummary(), news.getContent()))
-			.toList();
-
-		// 게시물 생성하기: 각 뉴스 기사별로 OpenAI API 호출 및 답변 생성
-		List<CompletableFuture<ChatCompletionResponse>> resultFutures = refPrompts.stream()
-			.map(refPrompt -> generatePostsAsync(
-				new ChatCompletionRequest(openAiModel, summaryContentSchema.getResponseFormat(), null, null)
-					.addDeveloperMessage(instructionPrompt)
-					.addUserTextMessage(topicPrompt)
-					.addUserTextMessage(refPrompt)
-			))
-			.toList();
-		List<ChatCompletionResponse> results = resultFutures.stream()
-			.map(CompletableFuture::join)
-			.toList();
+		// 게시물 생성
+		List<ChatCompletionResponse> results = generatePostsByNews(
+			GeneratePostsVo.of(request, limit), feedPagingResult);
 
 		// PostGroup 엔티티 생성
 		PostGroup postGroup = PostGroup.createPostGroup(null, rssFeed, request.getTopic(), request.getPurpose(),
@@ -136,7 +113,7 @@ public class PostService {
 			})
 			.toList();
 
-		// PostGroup 및 Post 리스트 엔티티 저장
+		// 엔티티 저장
 		SavePostGroupWithRssCursorAndPostsDto saveResult = postTransactionService.savePostGroupWithRssCursorAndPosts(
 			postGroup, postGroupRssCursor, posts);
 
@@ -148,21 +125,11 @@ public class PostService {
 	}
 
 	/**
-	 * 이미지 기반 게시물 생성 메서드
+	 * 이미지 기반 게시물 생성 및 저장 메서드
 	 */
 	public CreatePostsResponse createPostsByImage(CreatePostsRequest request, Integer limit) {
-		// 프롬프트 생성
-		String instructionPrompt = createPostPrompt.getInstruction();
-		String topicPrompt = createPostPrompt.getBasicTopicPrompt(request);
-		String imageRefPrompt = createPostPrompt.getImageRefPrompt();
-
 		// 게시물 생성
-		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(openAiModel,
-			summaryContentSchema.getResponseFormat(), limit, null)
-			.addDeveloperMessage(instructionPrompt)
-			.addUserTextMessage(topicPrompt)
-			.addUserImageMessage(imageRefPrompt, request.getImageUrls());
-		ChatCompletionResponse result = generatePosts(chatCompletionRequest);
+		ChatCompletionResponse result = generatePostsByImage(GeneratePostsVo.of(request, limit));
 
 		// PostGroup 엔티티 생성
 		PostGroup postGroup = PostGroup.createPostGroup(null, null, request.getTopic(), request.getPurpose(),
@@ -194,24 +161,93 @@ public class PostService {
 	}
 
 	/**
-	 * OpenAiClient의 getChatCompletion 메서드를 호출하여 게시물 생성을 요청하는 메서드
+	 * 게시물 추가 생성 메서드
+	 */
+	// public CreatePostsResponse createAdditionalPosts(Long postGroupId, Integer limit) {
+	// 	// PostGroup 조회
+	//
+	// 	//
+	// }
+
+	/**
+	 * 참고자료 없는 게시물 생성 메서드.
+	 * 프롬프트 설정 + 게시물 생성 작업 수행
 	 * 예외 발생 시 PostGenerateFailedException 발생
 	 */
-	private ChatCompletionResponse generatePosts(ChatCompletionRequest request) {
+	public ChatCompletionResponse generatePostsWithoutRef(GeneratePostsVo vo) {
+		// 프롬프트 생성: Instruction + 주제 Prompt
+		String instructionPrompt = createPostPrompt.getInstruction();
+		String topicPrompt = createPostPrompt.getBasicTopicPrompt(vo.topic(), vo.purpose(), vo.length(), vo.content());
+
+		// 게시물 생성
+		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(
+			openAiModel, summaryContentSchema.getResponseFormat(), vo.limit(), null)
+			.addDeveloperMessage(instructionPrompt)
+			.addUserTextMessage(topicPrompt);
+
 		try {
-			return openAiClient.getChatCompletion(request);
+			return openAiClient.getChatCompletion(chatCompletionRequest);
 		} catch (RuntimeException e) {
 			throw new CustomException(PostErrorCode.POST_GENERATE_FAILED);
 		}
 	}
 
 	/**
-	 * OpenAiClient의 getChatCompletionAsync 메서드를 호출하여 게시물 생성을 요청하는 메서드
-	 * 예외 발생 시 PostGenerateFailedException
+	 * 뉴스 기사 기반 게시물 생성 메서드.
+	 * 프롬프트 설정 + 게시물 생성 작업 수행
+	 * 예외 발생 시 PostGenerateFailedException 발생
 	 */
-	private CompletableFuture<ChatCompletionResponse> generatePostsAsync(ChatCompletionRequest request) {
+	public List<ChatCompletionResponse> generatePostsByNews(GeneratePostsVo vo, FeedPagingResult feedPagingResult) {
+		// 프롬프트 생성
+		String instructionPrompt = createPostPrompt.getInstruction();
+		String topicPrompt = createPostPrompt.getBasicTopicPrompt(
+			vo.topic(), vo.purpose(), vo.length(), vo.content());
+		List<String> refPrompts = feedPagingResult.getFeedItems().stream()
+			.map(news -> createPostPrompt.getNewsRefPrompt(news.getContentSummary(), news.getContent()))
+			.toList();
+
+		// 게시물 생성하기: 각 뉴스 기사별로 OpenAI API 호출 및 답변 생성
+		List<CompletableFuture<ChatCompletionResponse>> resultFutures = refPrompts.stream()
+			.map(refPrompt -> openAiClient.getChatCompletionAsync(
+				new ChatCompletionRequest(openAiModel, summaryContentSchema.getResponseFormat(), null, null)
+					.addDeveloperMessage(instructionPrompt)
+					.addUserTextMessage(topicPrompt)
+					.addUserTextMessage(refPrompt)
+			))
+			.toList();
+
+		// TODO: 해당 client에서 RuntimeException이 아닌 구분되는 예외를 던지도록 수정하기
 		try {
-			return openAiClient.getChatCompletionAsync(request);
+			return resultFutures.stream()
+				.map(CompletableFuture::join)
+				.toList();
+		} catch (RuntimeException e) {
+			throw new CustomException(PostErrorCode.POST_GENERATE_FAILED);
+		}
+	}
+
+	/**
+	 * 이미지 기반 게시물 생성 메서드.
+	 * 프롬프트 설정 + 게시물 생성 작업 수행
+	 * 예외 발생 시 PostGenerateFailedException 발생
+	 */
+	public ChatCompletionResponse generatePostsByImage(GeneratePostsVo vo) {
+		// 프롬프트 생성
+		String instructionPrompt = createPostPrompt.getInstruction();
+		String topicPrompt = createPostPrompt.getBasicTopicPrompt(
+			vo.topic(), vo.purpose(), vo.length(), vo.content());
+		String imageRefPrompt = createPostPrompt.getImageRefPrompt();
+
+		// 게시물 생성
+		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(openAiModel,
+			summaryContentSchema.getResponseFormat(), vo.limit(), null)
+			.addDeveloperMessage(instructionPrompt)
+			.addUserTextMessage(topicPrompt)
+			.addUserImageMessage(imageRefPrompt, vo.imageUrls());
+
+		// TODO: 해당 client에서 RuntimeException이 아닌 구분되는 예외를 던지도록 수정하기
+		try {
+			return openAiClient.getChatCompletion(chatCompletionRequest);
 		} catch (RuntimeException e) {
 			throw new CustomException(PostErrorCode.POST_GENERATE_FAILED);
 		}
@@ -221,24 +257,27 @@ public class PostService {
 	 * 요청한 뉴스 카테고리에 따라 뉴스 피드를 가져오는 메서드
 	 * 피드 가져오기 실패 시 NewsGetFailedException
 	 */
-	private FeedPagingResult getNewsFeed(RssFeed rssFeed, Integer limit) {
+	// TODO: 메서드 분리 없애기. 해당 client에서 RuntimeException이 아닌 구분되는 예외를 던지도록 수정하기
+	private FeedPagingResult getPagedNews(RssFeed rssFeed, String cursor, Integer limit) {
 		try {
-			return feedService.getPagedFeed(rssFeed.getUrl(), limit);
+			if (cursor == null) {
+				return feedService.getPagedFeed(rssFeed.getUrl(), limit);
+			} else {
+				return feedService.getPagedFeed(rssFeed.getUrl(), cursor, limit);
+			}
 		} catch (Exception e) {
 			throw new CustomException(PostErrorCode.NEWS_GET_FAILED);
 		}
 	}
 
 	/**
-	 * OpenAI API의 응답 content를 SummaryContentFormat 형태로 파싱하는 메서드
+	 * String으로 응답되는 OpenAI API의 응답 content를 SummaryContentFormat 형태로 파싱하는 메서드
 	 * 파싱에 실패한 경우 대체 content를 반환
 	 */
 	private SummaryContentFormat parseSummaryContentFormat(String content) {
 		try {
 			return objectMapper.readValue(content, SummaryContentFormat.class);
 		} catch (JsonProcessingException e) {
-			System.out.println(e);
-			System.out.println(e.getMessage());
 			return SummaryContentFormat.createAlternativeFormat("생성된 게시물", content);
 		}
 	}

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/vo/GeneratePostsVo.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/vo/GeneratePostsVo.java
@@ -32,6 +32,9 @@ public record GeneratePostsVo(
 	}
 
 	public static GeneratePostsVo of(PostGroup postGroup, Integer limit) {
+		// PostGroup의 feed가 null인 경우 처리
+		FeedCategoryType newsCategory = (postGroup.getFeed() == null) ? null : postGroup.getFeed().getCategory();
+
 		List<String> imageUrls = postGroup.getPostGroupImages().stream()
 			.map(PostGroupImage::getUrl)
 			.toList();
@@ -41,7 +44,7 @@ public record GeneratePostsVo(
 			postGroup.getPurpose(),
 			postGroup.getLength(),
 			postGroup.getContent(),
-			postGroup.getFeed().getCategory(),
+			newsCategory,
 			imageUrls,
 			limit
 		);

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/vo/GeneratePostsVo.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/vo/GeneratePostsVo.java
@@ -1,0 +1,49 @@
+package org.mainapplication.domain.post.service.vo;
+
+import java.util.List;
+
+import org.domainmodule.postgroup.entity.PostGroup;
+import org.domainmodule.postgroup.entity.PostGroupImage;
+import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
+import org.domainmodule.postgroup.entity.type.PostLengthType;
+import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
+import org.mainapplication.domain.post.controller.request.CreatePostsRequest;
+
+public record GeneratePostsVo(
+	String topic,
+	PostGroupPurposeType purpose,
+	PostLengthType length,
+	String content,
+	FeedCategoryType newsCategory,
+	List<String> imageUrls,
+	Integer limit
+) {
+
+	public static GeneratePostsVo of(CreatePostsRequest request, Integer limit) {
+		return new GeneratePostsVo(
+			request.getTopic(),
+			request.getPurpose(),
+			request.getLength(),
+			request.getContent(),
+			request.getNewsCategory(),
+			request.getImageUrls(),
+			limit
+		);
+	}
+
+	public static GeneratePostsVo of(PostGroup postGroup, Integer limit) {
+		List<String> imageUrls = postGroup.getPostGroupImages().stream()
+			.map(PostGroupImage::getUrl)
+			.toList();
+
+		return new GeneratePostsVo(
+			postGroup.getTopic(),
+			postGroup.getPurpose(),
+			postGroup.getLength(),
+			postGroup.getContent(),
+			postGroup.getFeed().getCategory(),
+			imageUrls,
+			limit
+		);
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/openai/prompt/CreatePostPrompt.java
+++ b/application/main-application/src/main/java/org/mainapplication/openai/prompt/CreatePostPrompt.java
@@ -1,6 +1,7 @@
 package org.mainapplication.openai.prompt;
 
-import org.mainapplication.domain.post.controller.request.CreatePostsRequest;
+import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
+import org.domainmodule.postgroup.entity.type.PostLengthType;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -19,17 +20,22 @@ public class CreatePostPrompt {
 	 * 게시물 그룹에 설정된 주제 Prompt.
 	 * 게시물 그룹의 정보를 받아서 게시물 주제에 대한 Prompt를 생성
 	 */
-	public String getBasicTopicPrompt(CreatePostsRequest request) {
+	public String getBasicTopicPrompt(
+		String topic,
+		PostGroupPurposeType purpose,
+		PostLengthType length,
+		String content
+	) {
 		return "지금부터 너가 생성해야 할 게시물의 내용을 알려줄게.\n"
-			+ request.getTopic()
+			+ topic
 			+ "라는 주제에 대해서 "
-			+ request.getPurpose().getValue()
+			+ purpose.getValue()
 			+ " 목적의 글을 생성해줘.\n"
 			+ "글자수는 "
-			+ request.getLength().getMaxLength()
+			+ length.getMaxLength()
 			+ "자 정도로 생성하고, 절대 초과해서는 안돼.\n"
 			+ "다음과 같은 내용을 반드시 포함해줘: \n"
-			+ request.getContent();
+			+ content;
 	}
 
 	/**

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
@@ -1,5 +1,8 @@
 package org.domainmodule.postgroup.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.domainmodule.agent.entity.Agent;
 import org.domainmodule.common.entity.BaseTimeEntity;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
@@ -17,6 +20,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -56,6 +60,10 @@ public class PostGroup extends BaseTimeEntity {
 
 	@Column(columnDefinition = "TEXT")
 	private String content;
+
+	// TODO: PostGroupRepository에 fetch join 쿼리 구현해야 함
+	@OneToMany(mappedBy = "postGroup")
+	private List<PostGroupImage> postGroupImages = new ArrayList<>();
 
 	@Builder
 	private PostGroup(Agent agent, RssFeed feed, String topic, PostGroupPurposeType purpose,

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroupRssCursor.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroupRssCursor.java
@@ -41,4 +41,8 @@ public class PostGroupRssCursor {
 			.newsId(newsId)
 			.build();
 	}
+
+	public void updateNewsId(String newsId) {
+		this.newsId = newsId;
+	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/exception/PostGroupNotFoundException.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/exception/PostGroupNotFoundException.java
@@ -1,0 +1,8 @@
+package org.domainmodule.postgroup.exception;
+
+public class PostGroupNotFoundException extends RuntimeException {
+
+	public PostGroupNotFoundException(Long postGroupId) {
+		super("게시물 그룹이 존재하지 않습니다. id: " + postGroupId);
+	}
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/exception/PostGroupRssCursorNotFoundException.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/exception/PostGroupRssCursorNotFoundException.java
@@ -1,0 +1,10 @@
+package org.domainmodule.postgroup.exception;
+
+import org.domainmodule.postgroup.entity.PostGroup;
+
+public class PostGroupRssCursorNotFoundException extends RuntimeException {
+
+	public PostGroupRssCursorNotFoundException(PostGroup postGroup) {
+		super("게시물 그룹에 RSS 피드 cursor가 존재하지 않습니다. postGroupId: " + postGroup.getId());
+	}
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRssCursorRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRssCursorRepository.java
@@ -1,7 +1,12 @@
 package org.domainmodule.postgroup.repository;
 
+import java.util.Optional;
+
+import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupRssCursor;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostGroupRssCursorRepository extends JpaRepository<PostGroupRssCursor, Long> {
+
+	Optional<PostGroupRssCursor> findByPostGroup(PostGroup postGroup);
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/rssfeed/exception/RssFeedNotFoundException.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/rssfeed/exception/RssFeedNotFoundException.java
@@ -1,8 +1,10 @@
 package org.domainmodule.rssfeed.exception;
 
+import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
+
 public class RssFeedNotFoundException extends RuntimeException {
 
-	public RssFeedNotFoundException(String message) {
-		super(message);
+	public RssFeedNotFoundException(FeedCategoryType feedCategory) {
+		super("RSS 피드가 존재하지 않습니다. category: " + feedCategory);
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #57 

## 📌 작업 내용 및 특이사항

### 1. PostService 메서드 분리
PostService 코드 중 '게시물 생성 API'와 '게시물 추가 생성 API'에서 중복되는 코드가 존재해, 이 부분을 메서드로 분리했습니다. 이때 메서드를 분리하면서 메서드 간에 인자를 전달하기 위해 VO를 따로 구현했습니다. (`GeneratePostsVo`)
```java
public class PostService {

    private ChatCompletionResponse generatePostsWithoutRef(GeneratePostsVo vo) { ... }

    private List<ChatCompletionResponse> generatePostsByNews(GeneratePostsVo vo, FeedPagingResult feedPagingResult) { ... }

    private ChatCompletionResponse generatePostsByImage(GeneratePostsVo vo) { ... }
}
```

### 2. PostService에 게시물 추가 생성 로직 구현
PostService의 createAdditionalPosts에서 PostGroup을 조회한 뒤, referenceType에 맞는 메서드로 분기 처리합니다.
```java
public class PostService {

    // PostGroup을 조회한 뒤 referenceType에 맞게 메서드 호출
    public CreatePostsResponse createAdditionalPosts(Long postGroupId, Integer limit) { ... }

    // referenceType이 NONE인 경우의 게시물 추가 생성
    private CreatePostsResponse createAdditionalPostsWithoutRef(PostGroup postGroup, Integer limit) { ... }

    // referenceType이 NEWS인 경우의 게시물 추가 생성
    private CreatePostsResponse createAdditionalPostsByNews(PostGroup postGroup, Integer limit) { ... }

    // referenceType이 IMAGE인 경우의 게시물 추가 생성
    private CreatePostsResponse createAdditionalPostsByImage(PostGroup postGroup, Integer limit) { ... }
}
```

결과적으로 PostService의 메서드들은 다음과 같습니다
1. 게시물 초기 생성 시
  - createPostsWithoutRef
  - createPostsByNews
  - createPostsByImage
2. 게시물 추가 생성 시
  - createAdditionalPosts
    - createAdditionalPostsWithoutRef
    - createAdditionalPostsByNews
    - createAdditionalPostsByImage

### 3. PostController에 게시물 추가 생성 API 추가
API 명세에 맞게 API를 추가했습니다.

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
- PostService의 크기가 꽤 많이 커졌고 메서드 구조도 복잡해졌습니다. 이후로도 게시물 수정 로직을 구현하면서 더 커질 예정이라, 용도에 맞게 service를 더 분리하고 앞에 facade를 두는 방식을 고려해봐야 할 것 같아요


