### PR TITLE
[#63] Feature: 뉴스 카테고리 목록 조회 API 구현

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/newscategory/controller/NewsCategoryController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/newscategory/controller/NewsCategoryController.java
@@ -1,0 +1,29 @@
+package org.mainapplication.domain.newscategory.controller;
+
+import java.util.List;
+
+import org.mainapplication.domain.newscategory.controller.response.NewsCategoryResponse;
+import org.mainapplication.domain.newscategory.service.NewsCategoryService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/news-categories")
+@RequiredArgsConstructor
+@Tag(name = "NewsCategory API", description = "뉴스 카테고리에 대한 요청을 처리하는 API입니다.")
+public class NewsCategoryController {
+
+	private final NewsCategoryService newsCategoryService;
+
+	@Operation(summary = "뉴스 카테고리 목록 조회 API", description = "서비스의 전체 뉴스 카테고리 목록을 조회합니다.")
+	@GetMapping
+	public ResponseEntity<List<NewsCategoryResponse>> getNewsCategories() {
+		return ResponseEntity.ok().body(newsCategoryService.getNewsCategories());
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/domain/newscategory/controller/response/NewsCategoryResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/newscategory/controller/response/NewsCategoryResponse.java
@@ -1,0 +1,17 @@
+package org.mainapplication.domain.newscategory.controller.response;
+
+import org.domainmodule.rssfeed.entity.RssFeed;
+import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
+
+public record NewsCategoryResponse(
+	FeedCategoryType category,
+	String name
+) {
+
+	public static NewsCategoryResponse of(RssFeed rssFeed) {
+		return new NewsCategoryResponse(
+			rssFeed.getCategory(),
+			rssFeed.getCategory().getValue()
+		);
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/domain/newscategory/service/NewsCategoryService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/newscategory/service/NewsCategoryService.java
@@ -1,0 +1,27 @@
+package org.mainapplication.domain.newscategory.service;
+
+import java.util.List;
+
+import org.domainmodule.rssfeed.entity.RssFeed;
+import org.domainmodule.rssfeed.repository.RssFeedRepository;
+import org.mainapplication.domain.newscategory.controller.response.NewsCategoryResponse;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NewsCategoryService {
+
+	private final RssFeedRepository rssFeedRepository;
+
+	/**
+	 * 전체 RssFeed를 조회하는 메서드
+	 */
+	public List<NewsCategoryResponse> getNewsCategories() {
+		List<RssFeed> rssFeeds = rssFeedRepository.findAll();
+		return rssFeeds.stream()
+			.map(NewsCategoryResponse::of)
+			.toList();
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #63 

## 📌 작업 내용 및 특이사항
main-application 모듈 newscategory 패키지에 뉴스 카테고리 목록 조회 API를 구현했습니다.
추후 만약 RSS가 아닌 별도의 뉴스 플랫폼을 사용하게 될 경우를 고려해, RSS에 한정되지 않도록 newscategory라는 이름을 사용했습니다.

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
단순한 조회 API라서 크게 고민할 부분은 없었습니다!