### PR TITLE
[#65] Feature: 게시물 그룹별 게시물 목록 조회 API 구현

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -1,10 +1,14 @@
 package org.mainapplication.domain.post.controller;
 
+import java.util.List;
+
 import org.mainapplication.domain.post.controller.request.CreatePostsRequest;
 import org.mainapplication.domain.post.controller.response.CreatePostsResponse;
+import org.mainapplication.domain.post.controller.response.type.PostResponse;
 import org.mainapplication.domain.post.service.PostService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,5 +50,14 @@ public class PostController {
 		@RequestParam(defaultValue = "5") Integer limit
 	) {
 		return ResponseEntity.ok(postService.createAdditionalPosts(postGroupId, limit));
+	}
+
+	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")
+	@GetMapping("/{postGroupId}/posts")
+	public ResponseEntity<List<PostResponse>> getPostsByPostGroup(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId
+	) {
+		return ResponseEntity.ok(postService.getPostsByPostGroup(postGroupId));
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
@@ -13,6 +13,9 @@ public enum PostErrorCode implements ErrorCodeStatus {
 	NO_NEWS_CATEGORY(HttpStatus.BAD_REQUEST, "뉴스와 함께 생성하려면, 뉴스 카테고리를 함께 선택해주세요."),
 	NO_IMAGE_URLS(HttpStatus.BAD_REQUEST, "이미지와 함께 생성하려면, 이미지를 첨부해주세요."),
 	NEWS_FEED_EXHAUSTED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),
+	POST_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 그룹이 존재하지 않습니다."),
+	RSS_CURSOR_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 그룹에 RSS cursor가 존재하지 않습니다."),
+	RSS_FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "RSS 피드가 존재하지 않습니다."),
 	POST_GENERATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 게시물 생성에 실패했습니다. 관리자에게 문의하세요."),
 	NEWS_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 뉴스 가져오기에 실패했습니다. 관리자에게 문의하세요.");
 

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.domainmodule.post.entity.Post;
 import org.domainmodule.post.entity.type.PostStatusType;
+import org.domainmodule.post.repository.PostRepository;
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupImage;
 import org.domainmodule.postgroup.entity.PostGroupRssCursor;
@@ -52,6 +53,7 @@ public class PostService {
 	private final SummaryContentSchema summaryContentSchema;
 
 	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final PostRepository postRepository;
 	private final PostGroupRepository postGroupRepository;
 	private final PostGroupRssCursorRepository postGroupRssCursorRepository;
 
@@ -398,5 +400,23 @@ public class PostService {
 		} catch (JsonProcessingException e) {
 			return SummaryContentFormat.createAlternativeFormat("생성된 게시물", content);
 		}
+	}
+
+	/**
+	 * postGroupId를 바탕으로 게시물 그룹 존재 여부를 확인하고, 해당 그룹의 게시물 목록을 반환하는 메서드
+	 * 게시물 그룹 조회 실패 시 PostGroupNotFoundException
+	 */
+	public List<PostResponse> getPostsByPostGroup(Long postGroupId) {
+		// PostGroup 엔티티 조회
+		PostGroup postGroup = postGroupRepository.findById(postGroupId)
+			.orElseThrow(() -> new PostGroupNotFoundException(postGroupId));
+
+		// Post 엔티티 리스트 조회
+		List<Post> posts = postRepository.findAllByPostGroup(postGroup);
+
+		// 결과 반환
+		return posts.stream()
+			.map(PostResponse::from)
+			.toList();
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -9,12 +9,9 @@ import org.domainmodule.post.repository.PostRepository;
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupImage;
 import org.domainmodule.postgroup.entity.PostGroupRssCursor;
-import org.domainmodule.postgroup.exception.PostGroupNotFoundException;
-import org.domainmodule.postgroup.exception.PostGroupRssCursorNotFoundException;
 import org.domainmodule.postgroup.repository.PostGroupRepository;
 import org.domainmodule.postgroup.repository.PostGroupRssCursorRepository;
 import org.domainmodule.rssfeed.entity.RssFeed;
-import org.domainmodule.rssfeed.exception.RssFeedNotFoundException;
 import org.domainmodule.rssfeed.repository.RssFeedRepository;
 import org.feedclient.service.FeedService;
 import org.feedclient.service.dto.FeedPagingResult;
@@ -101,7 +98,7 @@ public class PostService {
 
 		// 피드 받아오기
 		RssFeed rssFeed = rssFeedRepository.findByCategory(request.getNewsCategory())
-			.orElseThrow(() -> new RssFeedNotFoundException(request.getNewsCategory()));
+			.orElseThrow(() -> new CustomException(PostErrorCode.RSS_FEED_NOT_FOUND));
 		FeedPagingResult feedPagingResult = getPagedNews(rssFeed, null, limit);
 
 		// 게시물 생성
@@ -185,7 +182,7 @@ public class PostService {
 	public CreatePostsResponse createAdditionalPosts(Long postGroupId, Integer limit) {
 		// PostGroup 조회
 		PostGroup postGroup = postGroupRepository.findById(postGroupId)
-			.orElseThrow(() -> new PostGroupNotFoundException(postGroupId));
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
 		// referenceType에 따라 분기
 		return switch (postGroup.getReference()) {
@@ -228,9 +225,9 @@ public class PostService {
 	private CreatePostsResponse createAdditionalPostsByNews(PostGroup postGroup, Integer limit) {
 		// 피드 받아오기: RssFeed와 PostGroupRssCursor를 DB에서 조회
 		RssFeed rssFeed = rssFeedRepository.findByCategory(postGroup.getFeed().getCategory())
-			.orElseThrow(() -> new RssFeedNotFoundException(postGroup.getFeed().getCategory()));
+			.orElseThrow(() -> new CustomException(PostErrorCode.RSS_FEED_NOT_FOUND));
 		PostGroupRssCursor rssCursor = postGroupRssCursorRepository.findByPostGroup(postGroup)
-			.orElseThrow(() -> new PostGroupRssCursorNotFoundException(postGroup));
+			.orElseThrow(() -> new CustomException(PostErrorCode.RSS_CURSOR_NOT_FOUND));
 		FeedPagingResult feedPagingResult = getPagedNews(rssFeed, rssCursor.getNewsId(), limit);
 
 		// 피드가 고갈된 경우 에러 응답
@@ -404,12 +401,12 @@ public class PostService {
 
 	/**
 	 * postGroupId를 바탕으로 게시물 그룹 존재 여부를 확인하고, 해당 그룹의 게시물 목록을 반환하는 메서드
-	 * 게시물 그룹 조회 실패 시 PostGroupNotFoundException
+	 * 게시물 그룹 조회 실패 시 POST_GROUP_NOT_FOUND
 	 */
 	public List<PostResponse> getPostsByPostGroup(Long postGroupId) {
 		// PostGroup 엔티티 조회
 		PostGroup postGroup = postGroupRepository.findById(postGroupId)
-			.orElseThrow(() -> new PostGroupNotFoundException(postGroupId));
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
 		// Post 엔티티 리스트 조회
 		List<Post> posts = postRepository.findAllByPostGroup(postGroup);

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.domainmodule.post.entity.Post;
 import org.domainmodule.post.entity.type.PostStatusType;
+import org.domainmodule.postgroup.entity.PostGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,12 +14,16 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	// post와 SnsToken을 한번에 조회
 	@Query("""
-    SELECT p FROM Post p
-    JOIN FETCH p.postGroup pg
-    JOIN FETCH pg.agent a
-    JOIN SnsToken t ON t.agent.id = a.id
-    WHERE p.uploadTime BETWEEN :startTime AND :endTime
-    And p.status = :status
-""")
-	List<Post> findPostsWithSnsTokenByTimeRange(LocalDateTime startTime, LocalDateTime endTime, @Param("status") PostStatusType status);
+		    SELECT p FROM Post p
+		    JOIN FETCH p.postGroup pg
+		    JOIN FETCH pg.agent a
+		    JOIN SnsToken t ON t.agent.id = a.id
+		    WHERE p.uploadTime BETWEEN :startTime AND :endTime
+		    And p.status = :status
+		""")
+	List<Post> findPostsWithSnsTokenByTimeRange(LocalDateTime startTime, LocalDateTime endTime,
+		@Param("status") PostStatusType status);
+
+	// PostGroup에 해당하는 Post 리스트 조회
+	List<Post> findAllByPostGroup(PostGroup postGroup);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #65 

## 📌 작업 내용 및 특이사항

### 1. 그룹별 게시물 조회 API 구현
게시물 그룹별로 그룹에 해당하는 게시물 목록을 조회하는 API를 구현했습니다.
- postGroupId를 바탕으로 게시물 그룹 존재 여부를 확인
- 조회한 PostGroup으로 Post 목록을 조회

### 2. PostService 내 NotFoundException을 모두 CustomException으로 변경
기존에 domain 모듈에서 구현해둔 NotFoundException들이 RuntimeException을 상속받기 때문에 GlobalExceptionHandler에서 500번대 에러로 처리되는 문제가 있었습니다. 따라서 PostErrorCode에 NOT_FOUND에 대한 에러코드와 에러메시지를 정의하고, CustomException을 발생시키도록 변경했습니다.

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
repository 계층에서 엔티티 조회에 실패한 경우에 대한 예외를 domain 모듈에서 관리하는 방식이 적절하다고 생각했는데, CustomException이 main-application 모듈에 존재해 domain 모듈에서 사용할 수 없는 문제가 있었습니다. 때문에 RuntimeException을 상속받는 방향으로 구현하니 GlobalExceptionHandler에서 INTERNAL_SERVER_ERROR로 처리되는 문제가 발생했습니다.
따라서 당장은 post 패키지의 PostErrorCode에서 NotFound를 정의해두었는데, repository 계층에서의 예외를 main-application 모듈의 특정 패키지에서 관리하다보니 여러 패키지에서 에러코드가 중복될 수 있을 듯해 개선이 필요해보입니다!