### PR TITLE
[#68] Feature: 프롬프트 내역 조회

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/agent/exception/AgentErrorCode.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/agent/exception/AgentErrorCode.java
@@ -1,0 +1,16 @@
+package org.mainapplication.domain.agent.exception;
+
+import org.mainapplication.global.error.ErrorCodeStatus;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AgentErrorCode implements ErrorCodeStatus {
+
+	AGENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Agent를 찾을 수 없습니다.");
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/application/main-application/src/main/java/org/mainapplication/domain/agent/service/AgentService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/agent/service/AgentService.java
@@ -20,7 +20,6 @@ public class AgentService {
 	 * X API 로그인을 성공한 후 Agent와 SnsToken 생성 및 저장
 	 * @return 생성된 Agent 엔티티
 	 */
-
 	public Agent findOrCreateAgent(TwitterUserInfoDto userInfo) {
 		//TODO 임시 설정한 부분 (이후 securityContext에서 userId가져오기)
 		long userId = 1L;

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -1,10 +1,14 @@
 package org.mainapplication.domain.post.controller;
 
+import java.util.List;
+
 import org.mainapplication.domain.post.controller.request.CreatePostsRequest;
 import org.mainapplication.domain.post.controller.response.CreatePostsResponse;
+import org.mainapplication.domain.post.controller.response.PromptHistoriesRespone;
 import org.mainapplication.domain.post.service.PostService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -46,5 +50,15 @@ public class PostController {
 		@RequestParam(defaultValue = "5") Integer limit
 	) {
 		return ResponseEntity.ok(postService.createAdditionalPosts(postGroupId, limit));
+	}
+
+	@Operation(summary = "게시물 프롬프트 내역 조회 API", description = "게시물 결과 수정 단계에서 프롬프트 내역을 조회합니다.")
+	@GetMapping("/{postGroupId}/posts/{postId}/prompt-histories")
+	public ResponseEntity<List<PromptHistoriesRespone>> getPromptHistories(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@PathVariable Long postId
+	) {
+		return ResponseEntity.ok(postService.getPromptHistories(agentId, postGroupId, postId));
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/PromptHistoriesRespone.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/PromptHistoriesRespone.java
@@ -1,0 +1,37 @@
+package org.mainapplication.domain.post.controller.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.domainmodule.post.entity.PromptHistory;
+import org.domainmodule.post.entity.type.PostPromptType;
+
+public record PromptHistoriesRespone(
+	long id,
+	LocalDateTime createdAt,
+	String prompt,
+	String response,
+	PostPromptType type
+) {
+	public static PromptHistoriesRespone of(long id, LocalDateTime createdAt, String prompt, String response, PostPromptType promptType) {
+		return new PromptHistoriesRespone(id, createdAt, prompt, response, promptType);
+	}
+
+	public static PromptHistoriesRespone from(PromptHistory history) {
+		return new PromptHistoriesRespone(
+			history.getId(),
+			history.getCreatedAt(),
+			history.getPrompt(),
+			history.getResponse(),
+			history.getPromptType()
+		);
+	}
+
+	public static List<PromptHistoriesRespone> fromList(List<PromptHistory> histories) {
+		return histories.stream()
+			.map(PromptHistoriesRespone::from)
+			.collect(Collectors.toList());
+	}
+}
+

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.domainmodule.post.entity.Post;
+import org.domainmodule.post.entity.PromptHistory;
 import org.domainmodule.post.entity.type.PostStatusType;
+import org.domainmodule.post.repository.PromptHistoryRepository;
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupImage;
 import org.domainmodule.postgroup.entity.PostGroupRssCursor;
@@ -19,6 +21,7 @@ import org.feedclient.service.FeedService;
 import org.feedclient.service.dto.FeedPagingResult;
 import org.mainapplication.domain.post.controller.request.CreatePostsRequest;
 import org.mainapplication.domain.post.controller.response.CreatePostsResponse;
+import org.mainapplication.domain.post.controller.response.PromptHistoriesRespone;
 import org.mainapplication.domain.post.controller.response.type.PostResponse;
 import org.mainapplication.domain.post.exception.PostErrorCode;
 import org.mainapplication.domain.post.service.dto.SavePostGroupAndPostsDto;
@@ -38,6 +41,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -54,6 +58,7 @@ public class PostService {
 	private final ObjectMapper objectMapper = new ObjectMapper();
 	private final PostGroupRepository postGroupRepository;
 	private final PostGroupRssCursorRepository postGroupRssCursorRepository;
+	private final PromptHistoryRepository promptHistoryRepository;
 
 	@Value("${client.openai.model}")
 	private String openAiModel;
@@ -398,5 +403,22 @@ public class PostService {
 		} catch (JsonProcessingException e) {
 			return SummaryContentFormat.createAlternativeFormat("생성된 게시물", content);
 		}
+	}
+
+	/**
+	 * 과거 프롬프트 내역 가져오기
+	 * @return
+	 */
+	public List<PromptHistoriesRespone> getPromptHistories(Long agentId, Long postGroupId, Long postId) {
+		//TODO 임시 설정한 부분 (이후 securityContext에서 userId가져오기)
+		long userId = 1L;
+
+		List<PromptHistory> histories = promptHistoryRepository.findPromptHistoriesWithValidation(userId, agentId, postGroupId, postId);
+
+		if (histories.isEmpty()) {
+			throw new EntityNotFoundException("해당 조건에 맞는 게시물 또는 프롬프트 내역이 없습니다.");
+		}
+
+		return PromptHistoriesRespone.fromList(histories);
 	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PromptHistoryRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PromptHistoryRepository.java
@@ -1,0 +1,28 @@
+package org.domainmodule.post.repository;
+
+import java.util.List;
+
+import org.domainmodule.post.entity.PromptHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PromptHistoryRepository extends JpaRepository<PromptHistory, Long> {
+	@Query("""
+	select ph from PromptHistory ph
+	join fetch ph.post p
+	join fetch p.postGroup pg
+	join fetch pg.agent a
+	join fetch a.user u
+	where u.id = :userId
+	and a.id = :agentId
+	and pg.id = :postGroupId
+	and p.id = :postId
+	""")
+	List<PromptHistory> findPromptHistoriesWithValidation(
+		@Param("userId") Long userId,
+		@Param("agentId") Long agentId,
+		@Param("groupId") Long groupId,
+		@Param("postId") Long postId
+	);
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #68 

## 📌 작업 내용 및 특이사항
- 프롬프트 내역 조회 API 구현

## 🧐 고민한 점
- User, Agent, PostGroup, Post이 순서대로 요청을하여 존재여부를 체크할 것인지 ( 4번의 쿼리 )
- 1번의 쿼리로 PromptHistory의 리스트를 가져올 지 고민하였습니다.
- 각 단계마다 검증을 하면 예외를 상세하게 날릴 수 있지만 4번의 쿼리를 계속 날리는거 보다는 1번의 쿼리를 날리는게 더 좋다고 판단하였습니다.
- QueryDSL을 사용해도 좋지만 동적으로 변하는게 아니라 일단은 Jpql을 이용해 쿼리를 날렸습니다.

## 🚀 리뷰 해줬으면 하는 부분
- 이후 QueryDesl을 가져갈 지 아니면 단순한 쿼리는 JPQL을 이용할지 정하면 좋을 것 같습니다.

## 📚 기타 / 관련 문서
- 


