### PR TITLE
[#69] Feature: 게시물 개별 삭제 API 및 일괄 삭제 API 구현

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -62,7 +62,7 @@ public class PostController {
 		return ResponseEntity.ok(postService.getPostsByPostGroup(postGroupId));
 	}
 
-	@Operation(summary = "게시물 개별 삭제 API", description = "단건의 게시물을 개별 삭제합니다.")
+	@Operation(summary = "게시물 개별 삭제 API", description = "업로드가 확정되지 않은 단건의 게시물을 개별 삭제합니다.")
 	@DeleteMapping("/{postGroupId}/posts/{postId}")
 	public ResponseEntity<Void> deletePost(
 		@PathVariable Long agentId,
@@ -70,6 +70,17 @@ public class PostController {
 		@PathVariable Long postId
 	) {
 		postService.deletePost(postGroupId, postId);
+		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(summary = "게시물 일괄 삭제 API", description = "업로드가 확정되지 않은 여러 게시물들을 일괄 삭제합니다.")
+	@DeleteMapping("/{postGroupId}/posts")
+	public ResponseEntity<Void> deletePosts(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@RequestBody List<Long> postIds
+	) {
+		postService.deletePosts(postGroupId, postIds);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -8,6 +8,7 @@ import org.mainapplication.domain.post.controller.response.type.PostResponse;
 import org.mainapplication.domain.post.service.PostService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -59,5 +60,16 @@ public class PostController {
 		@PathVariable Long postGroupId
 	) {
 		return ResponseEntity.ok(postService.getPostsByPostGroup(postGroupId));
+	}
+
+	@Operation(summary = "게시물 개별 삭제 API", description = "단건의 게시물을 개별 삭제합니다.")
+	@DeleteMapping("/{postGroupId}/posts/{postId}")
+	public ResponseEntity<Void> deletePost(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@PathVariable Long postId
+	) {
+		postService.deletePost(postGroupId, postId);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum PostErrorCode implements ErrorCodeStatus {
 
+	// TODO: repository 계층 NotFound 에러코드는 특정 패키지 하위에서 관리하지 않도록 리팩토링하기
 	NO_NEWS_CATEGORY(HttpStatus.BAD_REQUEST, "뉴스와 함께 생성하려면, 뉴스 카테고리를 함께 선택해주세요."),
 	NO_IMAGE_URLS(HttpStatus.BAD_REQUEST, "이미지와 함께 생성하려면, 이미지를 첨부해주세요."),
 	NEWS_FEED_EXHAUSTED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
@@ -18,7 +18,7 @@ public enum PostErrorCode implements ErrorCodeStatus {
 	NO_NEWS_CATEGORY(HttpStatus.BAD_REQUEST, "뉴스와 함께 생성하려면, 뉴스 카테고리를 함께 선택해주세요."),
 	NO_IMAGE_URLS(HttpStatus.BAD_REQUEST, "이미지와 함께 생성하려면, 이미지를 첨부해주세요."),
 	INVALID_POST(HttpStatus.BAD_REQUEST, "게시물 그룹에 해당하는 게시물이 아닙니다."),
-	INVALID_DELETE_POST_STATUS(HttpStatus.BAD_REQUEST, "업로드가 확정된 게시물은 삭제할 수 없습니다."),
+	INVALID_DELETING_POST_STATUS(HttpStatus.BAD_REQUEST, "업로드가 확정된 게시물은 삭제할 수 없습니다."),
 	NEWS_FEED_EXHAUSTED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),
 	POST_GENERATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 게시물 생성에 실패했습니다. 관리자에게 문의하세요."),
 	NEWS_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 뉴스 가져오기에 실패했습니다. 관리자에게 문의하세요.");

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
@@ -11,12 +11,15 @@ import lombok.RequiredArgsConstructor;
 public enum PostErrorCode implements ErrorCodeStatus {
 
 	// TODO: repository 계층 NotFound 에러코드는 특정 패키지 하위에서 관리하지 않도록 리팩토링하기
-	NO_NEWS_CATEGORY(HttpStatus.BAD_REQUEST, "뉴스와 함께 생성하려면, 뉴스 카테고리를 함께 선택해주세요."),
-	NO_IMAGE_URLS(HttpStatus.BAD_REQUEST, "이미지와 함께 생성하려면, 이미지를 첨부해주세요."),
-	NEWS_FEED_EXHAUSTED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),
 	POST_GROUP_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 그룹이 존재하지 않습니다."),
+	POST_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물이 존재하지 않습니다."),
 	RSS_CURSOR_NOT_FOUND(HttpStatus.NOT_FOUND, "게시물 그룹에 RSS cursor가 존재하지 않습니다."),
 	RSS_FEED_NOT_FOUND(HttpStatus.NOT_FOUND, "RSS 피드가 존재하지 않습니다."),
+	NO_NEWS_CATEGORY(HttpStatus.BAD_REQUEST, "뉴스와 함께 생성하려면, 뉴스 카테고리를 함께 선택해주세요."),
+	NO_IMAGE_URLS(HttpStatus.BAD_REQUEST, "이미지와 함께 생성하려면, 이미지를 첨부해주세요."),
+	INVALID_POST(HttpStatus.BAD_REQUEST, "게시물 그룹에 해당하는 게시물이 아닙니다."),
+	INVALID_DELETE_POST_STATUS(HttpStatus.BAD_REQUEST, "업로드가 확정된 게시물은 삭제할 수 없습니다."),
+	NEWS_FEED_EXHAUSTED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),
 	POST_GENERATE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 게시물 생성에 실패했습니다. 관리자에게 문의하세요."),
 	NEWS_GET_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류로 뉴스 가져오기에 실패했습니다. 관리자에게 문의하세요.");
 

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostTransactionService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostTransactionService.java
@@ -105,4 +105,12 @@ public class PostTransactionService {
 		List<Post> savedPosts = savePosts(posts);
 		return new SavePostGroupWithImagesAndPostsDto(savedPostGroup, savedPostGroupImages, savedPosts);
 	}
+
+	/**
+	 * Post를 삭제하는 메서드
+	 */
+	@Transactional
+	public void deletePost(Post post) {
+		postRepository.delete(post);
+	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostTransactionService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostTransactionService.java
@@ -107,10 +107,18 @@ public class PostTransactionService {
 	}
 
 	/**
-	 * Post를 삭제하는 메서드
+	 * Post를 단건 삭제하는 메서드
 	 */
 	@Transactional
 	public void deletePost(Post post) {
 		postRepository.delete(post);
+	}
+
+	/**
+	 * Post 리스트를 삭제하는 메서드
+	 */
+	@Transactional
+	public void deletePosts(List<Post> posts) {
+		postRepository.deleteAll(posts);
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #69 

## 📌 작업 내용 및 특이사항

### 1. 게시물 개별 삭제 API 구현
게시물 개별 삭제 API를 구현했습니다. 삭제를 위해 다음 검증 로직을 작성했습니다.
- PostGroup 및 Post가 존재하는지 확인
- PostGroup에 해당하는 Post인지 확인
- Post가 삭제 가능한 상태인지 확인 (생성됨, 수정중, 수정완료)

### 2. 게시물 일괄 삭제 API 구현
게시물 일괄 삭제 API를 구현했습니다. 삭제를 위해 다음 검증 로직을 작성했습니다.
- PostGroup 및 Post가 존재하는지 확인: Post 리스트 중 하나라도 존재하지 않으면 에러 응답
- PostGroup에 해당하는 Post인지 확인: Post 리스트 중 하나라도 해당하지 않으면 에러 응답
- Post가 삭제 가능한 상태인지 확인 (생성됨, 수정중, 수정완료): Post 리스트 중 하나라도 삭제 불가능한 상태이면 에러 응답

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
현재 CustomException을 사용하는 방식에서는 에러메시지에 변수를 추가할 수 없어서, 구체적으로 어떤 id의 Post에서 예외가 발생했는지에 대한 정보를 함께 응답해줄 수 없더라구요. 그래서 당장은 세부정보 없이 에러메시지만 응답하도록 구현했는데, 추후 개선할 필요가 있어보입니다!