### PR TITLE
[#96] Feature: 그룹별 게시물 조회 API 응답 형식 수정 & 게시물 조회 시 응답에 이미지 누락되는 문제 해결

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -8,6 +8,7 @@ import org.mainapplication.domain.post.controller.request.SinglePostUpdateReques
 import org.mainapplication.domain.post.controller.request.UpdatePostContentRequest;
 import org.mainapplication.domain.post.controller.request.UpdatePostsRequest;
 import org.mainapplication.domain.post.controller.response.CreatePostsResponse;
+import org.mainapplication.domain.post.controller.response.GetPostGroupPostsResponse;
 import org.mainapplication.domain.post.controller.response.PromptHistoriesResponse;
 import org.mainapplication.domain.post.controller.response.type.PostResponse;
 import org.mainapplication.domain.post.service.PostService;
@@ -138,7 +139,7 @@ public class PostController {
 
 	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")
 	@GetMapping("/{postGroupId}/posts")
-	public ResponseEntity<List<PostResponse>> getPostsByPostGroup(
+	public ResponseEntity<GetPostGroupPostsResponse> getPostsByPostGroup(
 		@PathVariable Long agentId,
 		@PathVariable Long postGroupId
 	) {

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/request/CreatePostsRequest.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/request/CreatePostsRequest.java
@@ -2,9 +2,9 @@ package org.mainapplication.domain.post.controller.request;
 
 import java.util.List;
 
+import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
 import org.domainmodule.postgroup.entity.type.PostGroupReferenceType;
-import org.domainmodule.postgroup.entity.type.PostLengthType;
 import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
 import org.springframework.lang.Nullable;
 
@@ -40,7 +40,7 @@ public class CreatePostsRequest {
 
 	@Schema(description = "생성할 게시물의 길이에 대한 Enum", example = "SHORT")
 	@NotNull(message = "게시물의 길이를 선택해주세요.")
-	private PostLengthType length;
+	private PostGroupLengthType length;
 
 	@Schema(description = "생성할 게시물에 포함될 핵심 내용", example = "'이런 메뉴는 어떨까?'와 같은 마무리 멘트")
 	@NotNull(message = "게시물의 핵심 내용을 입력해주세요.")

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/GetPostGroupPostsResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/GetPostGroupPostsResponse.java
@@ -14,11 +14,13 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Schema
+@Schema(description = "게시물 그룹별 게시물 목록 조회 API 응답 본문")
 public class GetPostGroupPostsResponse {
 
+	@Schema(description = "게시물 그룹 정보")
 	private PostGroupResponse postGroup;
 
+	@Schema(description = "게시물 그룹에 해당하는 게시물 목록")
 	private List<PostResponse> posts;
 
 	public static GetPostGroupPostsResponse of(PostGroup postGroup, List<Post> posts) {

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/GetPostGroupPostsResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/GetPostGroupPostsResponse.java
@@ -1,0 +1,30 @@
+package org.mainapplication.domain.post.controller.response;
+
+import java.util.List;
+
+import org.domainmodule.post.entity.Post;
+import org.domainmodule.postgroup.entity.PostGroup;
+import org.mainapplication.domain.post.controller.response.type.PostGroupResponse;
+import org.mainapplication.domain.post.controller.response.type.PostResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema
+public class GetPostGroupPostsResponse {
+
+	private PostGroupResponse postGroup;
+
+	private List<PostResponse> posts;
+
+	public static GetPostGroupPostsResponse of(PostGroup postGroup, List<Post> posts) {
+		List<PostResponse> postResponses = posts.stream()
+			.map(PostResponse::from)
+			.toList();
+		return new GetPostGroupPostsResponse(PostGroupResponse.from(postGroup), postResponses);
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupImageResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupImageResponse.java
@@ -9,13 +9,16 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Schema
+@Schema(description = "게시물 그룹 이미지 응답 객체")
 public class PostGroupImageResponse {
 
+	@Schema(description = "게시물 그룹 이미지 id", example = "1")
 	private Long id;
 
+	@Schema(description = "게시물 그룹 id", example = "1")
 	private Long postGroupId;
 
+	@Schema(description = "이미지 URL", example = "https://~")
 	private String url;
 
 	public static PostGroupImageResponse from(PostGroupImage postGroupImage) {

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupImageResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupImageResponse.java
@@ -1,0 +1,28 @@
+package org.mainapplication.domain.post.controller.response.type;
+
+import org.domainmodule.postgroup.entity.PostGroupImage;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema
+public class PostGroupImageResponse {
+
+	private Long id;
+
+	private Long postGroupId;
+
+	private String url;
+
+	public static PostGroupImageResponse from(PostGroupImage postGroupImage) {
+		return new PostGroupImageResponse(
+			postGroupImage.getId(),
+			postGroupImage.getPostGroup().getId(),
+			postGroupImage.getUrl()
+		);
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupResponse.java
@@ -1,0 +1,52 @@
+package org.mainapplication.domain.post.controller.response.type;
+
+import java.util.List;
+
+import org.domainmodule.postgroup.entity.PostGroup;
+import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
+import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
+import org.domainmodule.postgroup.entity.type.PostGroupReferenceType;
+import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Schema
+public class PostGroupResponse {
+
+	private Long id;
+
+	private String topic;
+
+	private PostGroupPurposeType purpose;
+
+	private PostGroupReferenceType reference;
+
+	private FeedCategoryType newsCategory;
+
+	private List<PostGroupImageResponse> postGroupImages;
+
+	private PostGroupLengthType length;
+
+	private String content;
+
+	public static PostGroupResponse from(PostGroup postGroup) {
+		List<PostGroupImageResponse> postGroupImages = postGroup.getPostGroupImages().stream()
+			.map(PostGroupImageResponse::from)
+			.toList();
+		return new PostGroupResponse(
+			postGroup.getId(),
+			postGroup.getTopic(),
+			postGroup.getPurpose(),
+			postGroup.getReference(),
+			(postGroup.getFeed() != null) ? postGroup.getFeed().getCategory() : null,
+			postGroupImages,
+			postGroup.getLength(),
+			postGroup.getContent()
+		);
+	}
+}

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupResponse.java
@@ -15,23 +15,31 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Schema
+@Schema(description = "게시물 그룹 응답 객체")
 public class PostGroupResponse {
 
+	@Schema(description = "게시물 그룹 id", example = "1")
 	private Long id;
 
+	@Schema(description = "게시물 그룹의 주제", example = "점심 메뉴 추천")
 	private String topic;
 
+	@Schema(description = "게시물 그룹의 목적에 대한 Enum", example = "OPINION")
 	private PostGroupPurposeType purpose;
 
+	@Schema(description = "게시물 생성 방식(참고 자료)에 대한 Enum", example = "NONE")
 	private PostGroupReferenceType reference;
 
+	@Schema(description = "뉴스를 참고하는 경우, 뉴스 카테고리", example = "null")
 	private FeedCategoryType newsCategory;
 
+	@Schema(description = "이미지를 참고하는 경우, 이미지 객체 리스트", example = "null")
 	private List<PostGroupImageResponse> postGroupImages;
 
+	@Schema(description = "게시물 그룹의 길이에 대한 Enum", example = "SHORT")
 	private PostGroupLengthType length;
 
+	@Schema(description = "게시물 그룹의 핵심 포함 내용", example = "'이런 메뉴는 어떨까?'와 같은 마무리 멘트")
 	private String content;
 
 	public static PostGroupResponse from(PostGroup postGroup) {

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostImageResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostImageResponse.java
@@ -1,9 +1,14 @@
 package org.mainapplication.domain.post.controller.response.type;
 
+import org.domainmodule.post.entity.PostImage;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Schema(description = "게시물 이미지 응답 객체")
 public class PostImageResponse {
 
@@ -15,4 +20,12 @@ public class PostImageResponse {
 
 	@Schema(description = "이미지 URL", example = "https://~")
 	private String url;
+
+	public static PostImageResponse from(PostImage postImage) {
+		return new PostImageResponse(
+			postImage.getId(),
+			postImage.getPost().getId(),
+			postImage.getUrl()
+		);
+	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostResponse.java
@@ -44,6 +44,10 @@ public class PostResponse {
 	private LocalDateTime uploadTime;
 
 	public static PostResponse from(Post post) {
+		List<PostImageResponse> postImages = post.getPostImages().stream()
+			.map(PostImageResponse::from)
+			.toList();
+
 		return new PostResponse(
 			post.getId(),
 			post.getCreatedAt(),
@@ -51,7 +55,7 @@ public class PostResponse {
 			post.getDisplayOrder(),
 			post.getSummary(),
 			post.getContent(),
-			null,
+			postImages,
 			post.getStatus(),
 			post.getUploadTime()
 		);

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -26,6 +26,7 @@ import org.mainapplication.domain.post.controller.request.UpdatePostContentReque
 import org.mainapplication.domain.post.controller.request.UpdatePostsRequest;
 import org.mainapplication.domain.post.controller.request.type.UpdatePostsRequestItem;
 import org.mainapplication.domain.post.controller.response.CreatePostsResponse;
+import org.mainapplication.domain.post.controller.response.GetPostGroupPostsResponse;
 import org.mainapplication.domain.post.controller.response.type.PostResponse;
 import org.mainapplication.domain.post.exception.PostErrorCode;
 import org.mainapplication.domain.post.service.dto.SavePostGroupAndPostsDto;
@@ -497,7 +498,7 @@ public class PostService {
 	 * postGroupId를 바탕으로 게시물 그룹 존재 여부를 확인하고, 해당 그룹의 게시물 목록을 반환하는 메서드
 	 * 게시물 그룹 조회 실패 시 POST_GROUP_NOT_FOUND
 	 */
-	public List<PostResponse> getPostsByPostGroup(Long postGroupId) {
+	public GetPostGroupPostsResponse getPostsByPostGroup(Long postGroupId) {
 		// PostGroup 엔티티 조회
 		PostGroup postGroup = postGroupRepository.findById(postGroupId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
@@ -506,9 +507,7 @@ public class PostService {
 		List<Post> posts = postRepository.findAllByPostGroup(postGroup);
 
 		// 결과 반환
-		return posts.stream()
-			.map(PostResponse::from)
-			.toList();
+		return GetPostGroupPostsResponse.of(postGroup, posts);
 	}
 
 	/**

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -542,7 +542,7 @@ public class PostService {
 	}
 
 	/**
-	 * 게시물의 내용 및 이미지를 수정 메서드.
+	 * 게시물의 내용 및 이미지 수정 메서드.
 	 */
 	private void updatePostImages(Post post, UpdatePostContentRequest request) {
 		// 수정 타입 검증

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/vo/GeneratePostsVo.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/vo/GeneratePostsVo.java
@@ -4,15 +4,15 @@ import java.util.List;
 
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupImage;
+import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
-import org.domainmodule.postgroup.entity.type.PostLengthType;
 import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
 import org.mainapplication.domain.post.controller.request.CreatePostsRequest;
 
 public record GeneratePostsVo(
 	String topic,
 	PostGroupPurposeType purpose,
-	PostLengthType length,
+	PostGroupLengthType length,
 	String content,
 	FeedCategoryType newsCategory,
 	List<String> imageUrls,

--- a/application/main-application/src/main/java/org/mainapplication/openai/prompt/CreatePostPrompt.java
+++ b/application/main-application/src/main/java/org/mainapplication/openai/prompt/CreatePostPrompt.java
@@ -1,7 +1,7 @@
 package org.mainapplication.openai.prompt;
 
+import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
-import org.domainmodule.postgroup.entity.type.PostLengthType;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -23,7 +23,7 @@ public class CreatePostPrompt {
 	public String getBasicTopicPrompt(
 		String topic,
 		PostGroupPurposeType purpose,
-		PostLengthType length,
+		PostGroupLengthType length,
 		String content
 	) {
 		return "지금부터 너가 생성해야 할 게시물의 내용을 알려줄게.\n"

--- a/application/main-application/src/test/java/org/mainapplication/domain/post/service/PostServiceTest.java
+++ b/application/main-application/src/test/java/org/mainapplication/domain/post/service/PostServiceTest.java
@@ -3,9 +3,9 @@ package org.mainapplication.domain.post.service;
 import java.io.IOException;
 import java.util.List;
 
+import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
 import org.domainmodule.postgroup.entity.type.PostGroupReferenceType;
-import org.domainmodule.postgroup.entity.type.PostLengthType;
 import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class PostServiceTest {
 			PostGroupReferenceType.NONE,
 			null,
 			null,
-			PostLengthType.SHORT,
+			PostGroupLengthType.SHORT,
 			"오늘 이 메뉴는 어떨까나~"
 		);
 
@@ -62,7 +62,7 @@ class PostServiceTest {
 			PostGroupReferenceType.NEWS,
 			FeedCategoryType.INVEST,
 			null,
-			PostLengthType.SHORT,
+			PostGroupLengthType.SHORT,
 			"'화성 가즈아~~'와 같은 추임새를 포함하기"
 		);
 
@@ -87,7 +87,7 @@ class PostServiceTest {
 			PostGroupReferenceType.IMAGE,
 			null,
 			List.of("https://instead-dev.s3.ap-northeast-2.amazonaws.com/NML2.jpeg"),
-			PostLengthType.SHORT,
+			PostGroupLengthType.SHORT,
 			"텡커레이 no.10의 시트러스한 상큼함과 깔끔함을 강조하는 홍보 멘트, '좋은 시간 좋은 술.'과 같은 느끼한 마무리 멘트"
 		);
 

--- a/domain/domain-module/src/main/java/org/domainmodule/post/entity/Post.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/entity/Post.java
@@ -1,6 +1,8 @@
 package org.domainmodule.post.entity;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.domainmodule.common.entity.BaseAuditEntity;
 import org.domainmodule.post.entity.type.PostStatusType;
@@ -16,6 +18,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,6 +54,9 @@ public class Post extends BaseAuditEntity {
 	private LocalDateTime uploadTime;
 
 	private Integer displayOrder;
+
+	@OneToMany(mappedBy = "post")
+	private List<PostImage> postImages = new ArrayList<>();
 
 	@Builder
 	private Post(

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -26,6 +26,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		@Param("status") PostStatusType status);
 
 	// PostGroup에 해당하는 Post 리스트 조회
+	@Query("""
+			select p from Post p
+			join fetch p.postImages pi
+			where p.postGroup = :postGroup
+		""")
 	List<Post> findAllByPostGroup(PostGroup postGroup);
 
 	// PostGroup에 해당하는 Post 중에서, 상태가 GENERATED인 게시물 중 order가 가장 큰 Post 조회

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
@@ -5,9 +5,9 @@ import java.util.List;
 
 import org.domainmodule.agent.entity.Agent;
 import org.domainmodule.common.entity.BaseTimeEntity;
+import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
 import org.domainmodule.postgroup.entity.type.PostGroupReferenceType;
-import org.domainmodule.postgroup.entity.type.PostLengthType;
 import org.domainmodule.rssfeed.entity.RssFeed;
 
 import jakarta.persistence.Column;
@@ -40,10 +40,6 @@ public class PostGroup extends BaseTimeEntity {
 	@JoinColumn(name = "agent_id")
 	private Agent agent;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "feed_id")
-	private RssFeed feed;
-
 	@Column(nullable = false, length = 255)
 	private String topic;
 
@@ -55,24 +51,27 @@ public class PostGroup extends BaseTimeEntity {
 	@Column(nullable = false)
 	private PostGroupReferenceType reference;
 
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "feed_id")
+	private RssFeed feed;
+
+	@OneToMany(mappedBy = "postGroup")
+	private List<PostGroupImage> postGroupImages = new ArrayList<>();
+
 	@Enumerated(EnumType.STRING)
-	private PostLengthType length;
+	private PostGroupLengthType length;
 
 	@Column(columnDefinition = "TEXT")
 	private String content;
 
-	// TODO: PostGroupRepository에 fetch join 쿼리 구현해야 함
-	@OneToMany(mappedBy = "postGroup")
-	private List<PostGroupImage> postGroupImages = new ArrayList<>();
-
 	@Builder
 	private PostGroup(Agent agent, RssFeed feed, String topic, PostGroupPurposeType purpose,
-		PostGroupReferenceType reference, PostLengthType length, String content) {
+		PostGroupReferenceType reference, PostGroupLengthType length, String content) {
 		this.agent = agent;
-		this.feed = feed;
 		this.topic = topic;
 		this.purpose = purpose;
 		this.reference = reference;
+		this.feed = feed;
 		this.length = length;
 		this.content = content;
 	}
@@ -83,7 +82,7 @@ public class PostGroup extends BaseTimeEntity {
 		String topic,
 		PostGroupPurposeType purpose,
 		PostGroupReferenceType reference,
-		PostLengthType length,
+		PostGroupLengthType length,
 		String content
 	) {
 		return PostGroup.builder()

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/type/PostGroupLengthType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/type/PostGroupLengthType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum PostLengthType {
+public enum PostGroupLengthType {
 	SHORT(200, "짧은 게시물"),
 	MEDIUM(400, "보통 게시물"),
 	LONG(600, "긴 게시물");


### PR DESCRIPTION
## 🌱 관련 이슈
- close #96 

## 📌 작업 내용 및 특이사항

### 1. 그룹별 게시물 조회 API 변경
해당 API 응답에 게시물 그룹 정보가 함께 포함되어야 한다는 요구사항에 따라 응답 형식을 변경하였습니다. 기존 List<PostResponse>로 응답하던 방식에서, GetPostGroupPostsResponse로 응답하도록 변경했습니다.
```java
public class GetPostGroupPostsResponse {

	@Schema(description = "게시물 그룹 정보")
	private PostGroupResponse postGroup;

	@Schema(description = "게시물 그룹에 해당하는 게시물 목록")
	private List<PostResponse> posts;

	public static GetPostGroupPostsResponse of(PostGroup postGroup, List<Post> posts) {
		List<PostResponse> postResponses = posts.stream()
			.map(PostResponse::from)
			.toList();
		return new GetPostGroupPostsResponse(PostGroupResponse.from(postGroup), postResponses);
	}
}
```

### 2. 게시물 조회 시 응답에 이미지 누락되는 문제 해결
기존 PostResponse에서 Post 엔티티에 대한 정적 팩토리 메서드인 from 메서드에서, 이미지 목록에 대한 필드를 따로 변환하지 않고 null로 응답하는 부분을 수정했습니다.

