### PR TITLE
[#99] Fix: 게시물 조회 시 잘못된 join 수정

### DIFF
--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -28,7 +28,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	// PostGroup에 해당하는 Post 리스트 조회
 	@Query("""
 			select p from Post p
-			join fetch p.postImages pi
+			left join fetch p.postImages pi
 			where p.postGroup = :postGroup
 		""")
 	List<Post> findAllByPostGroup(PostGroup postGroup);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #99 

## 📌 작업 내용 및 특이사항
게시물 조회 시 게시물 이미지와의 잘못된 join으로 인한 버그를 수정했습니다.