### PR TITLE
[#117] Feature: 게시물 생성 횟수 제한 기능 추가 및 그룹별 게시물 조회 API 응답 본문 수정

### DIFF
--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -50,9 +50,9 @@ public class PostController {
 			- NEWS (뉴스 참고): newsCategory를 지정하고, imageUrls를 비워주세요.
 			- IMAGE (이미지 참고): imageUrls를 설정하고, newsCategory를 비워주세요.
 
-			**2. 뉴스를 참고해 생성하는 경우, 응답 본문에 eof가 포함됩니다.**
+			**2. 응답 본문에 eof가 포함됩니다.**
 
-			한 시점에 사용 가능한 피드 수에 제한이 있기 때문에, 추가 생성이 가능한지 여부를 eof로 구분합니다."""
+			게시물 그룹별 최대 게시물 생성 가능 횟수를 채우게 되면 eof가 true로 응답됩니다. 이 경우 추가 생성이 제한됩니다."""
 	)
 	@PostMapping("/posts")
 	public ResponseEntity<CreatePostsResponse> createPosts(
@@ -72,9 +72,9 @@ public class PostController {
 		description = """
 			기존 게시물 그룹에 새 게시물을 추가합니다.
 
-			**뉴스를 참고해 생성하는 게시물 그룹의 경우, 응답 본문에 eof가 포함됩니다.**
+			**응답 본문에 eof가 포함됩니다.**
 
-			한 시점에 사용 가능한 피드 수에 제한이 있기 때문에, 추가 생성이 가능한지 여부를 eof로 구분합니다."""
+			게시물 그룹별 최대 게시물 생성 가능 횟수를 채우게 되면 eof가 true로 응답됩니다. 이 경우 추가 생성이 제한됩니다."""
 	)
 	@PostMapping("/{postGroupId}/posts")
 	public ResponseEntity<CreatePostsResponse> createAdditionalPosts(

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/PostController.java
@@ -13,6 +13,7 @@ import org.mainapplication.domain.post.controller.response.PromptHistoriesRespon
 import org.mainapplication.domain.post.controller.response.type.PostResponse;
 import org.mainapplication.domain.post.service.PostService;
 import org.mainapplication.domain.post.service.PromptHistoryService;
+import org.mainapplication.global.constants.PostGenerationCount;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -56,7 +57,7 @@ public class PostController {
 	@PostMapping("/posts")
 	public ResponseEntity<CreatePostsResponse> createPosts(
 		@PathVariable Long agentId,
-		@RequestParam(defaultValue = "5") Integer limit,
+		@RequestParam(defaultValue = PostGenerationCount.POST_GENERATION_POST_COUNT) Integer limit,
 		@Validated @RequestBody CreatePostsRequest createPostsRequest
 	) {
 		return switch (createPostsRequest.getReference()) {
@@ -79,7 +80,7 @@ public class PostController {
 	public ResponseEntity<CreatePostsResponse> createAdditionalPosts(
 		@PathVariable Long agentId,
 		@PathVariable Long postGroupId,
-		@RequestParam(defaultValue = "5") Integer limit
+		@RequestParam(defaultValue = PostGenerationCount.POST_GENERATION_POST_COUNT) Integer limit
 	) {
 		return ResponseEntity.ok(postService.createAdditionalPosts(postGroupId, limit));
 	}

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupResponse.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/controller/response/type/PostGroupResponse.java
@@ -7,6 +7,7 @@ import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
 import org.domainmodule.postgroup.entity.type.PostGroupReferenceType;
 import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
+import org.mainapplication.global.constants.PostGenerationCount;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AccessLevel;
@@ -42,10 +43,14 @@ public class PostGroupResponse {
 	@Schema(description = "게시물 그룹의 핵심 포함 내용", example = "'이런 메뉴는 어떨까?'와 같은 마무리 멘트")
 	private String content;
 
+	@Schema(description = "게시물 그룹의 생성 횟수 제한 도달 여부", example = "false")
+	private Boolean eof;
+
 	public static PostGroupResponse from(PostGroup postGroup) {
 		List<PostGroupImageResponse> postGroupImages = postGroup.getPostGroupImages().stream()
 			.map(PostGroupImageResponse::from)
 			.toList();
+		boolean eof = (postGroup.getGenerationCount() >= PostGenerationCount.MAX_POST_GENERATION_COUNT);
 		return new PostGroupResponse(
 			postGroup.getId(),
 			postGroup.getTopic(),
@@ -54,7 +59,8 @@ public class PostGroupResponse {
 			(postGroup.getFeed() != null) ? postGroup.getFeed().getCategory() : null,
 			postGroupImages,
 			postGroup.getLength(),
-			postGroup.getContent()
+			postGroup.getContent(),
+			eof
 		);
 	}
 }

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/exception/PostErrorCode.java
@@ -22,7 +22,8 @@ public enum PostErrorCode implements ErrorCodeStatus {
 	NO_IMAGE_URLS(HttpStatus.BAD_REQUEST, "이미지와 함께 생성하려면, 이미지를 첨부해주세요."),
 	INVALID_POST(HttpStatus.BAD_REQUEST, "게시물 그룹에 해당하는 게시물이 아닙니다."),
 	INVALID_DELETING_POST_STATUS(HttpStatus.BAD_REQUEST, "업로드가 확정된 게시물은 삭제할 수 없습니다."),
-	NEWS_FEED_EXHAUSTED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),
+	EXHAUSTED_GENERATION_COUNT(HttpStatus.BAD_REQUEST, "게시물 생성 가능 횟수를 전부 사용했습니다. 새로운 게시물 그룹을 이용해주세요."),
+	EXHAUSTED_NEWS_FEED(HttpStatus.BAD_REQUEST, "현재 최신 피드를 전부 사용했습니다. 피드가 갱신될 때까지 시간이 걸릴 수 있습니다."),
 	INVALID_UPDATING_POST_TYPE(HttpStatus.BAD_REQUEST, "수정하려는 필드를 updateType에 맞게 정확히 포함해주세요."),
 
 	// INTERNAL_SERVER_ERROR

--- a/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
+++ b/application/main-application/src/main/java/org/mainapplication/domain/post/service/PostService.java
@@ -80,7 +80,7 @@ public class PostService {
 
 		// PostGroup 엔티티 생성
 		PostGroup postGroup = PostGroup.createPostGroup(null, null, request.getTopic(), request.getPurpose(),
-			request.getReference(), request.getLength(), request.getContent());
+			request.getReference(), request.getLength(), request.getContent(), limit);
 
 		// Post 엔티티 생성: OpenAI API 응답의 choices에서 답변 꺼내 json으로 파싱 후 엔티티 생성
 		// displayOrder 지정에 사용할 반복변수를 위해 for문 사용
@@ -122,7 +122,7 @@ public class PostService {
 
 		// PostGroup 엔티티 생성
 		PostGroup postGroup = PostGroup.createPostGroup(null, rssFeed, request.getTopic(), request.getPurpose(),
-			request.getReference(), request.getLength(), request.getContent());
+			request.getReference(), request.getLength(), request.getContent(), limit);
 
 		// PostGroupRssCursor 엔티티 생성
 		String cursor = feedPagingResult.getFeedItems().get(feedPagingResult.getFeedItems().size() - 1).getId();
@@ -164,7 +164,7 @@ public class PostService {
 
 		// PostGroup 엔티티 생성
 		PostGroup postGroup = PostGroup.createPostGroup(null, null, request.getTopic(), request.getPurpose(),
-			request.getReference(), request.getLength(), request.getContent());
+			request.getReference(), request.getLength(), request.getContent(), limit);
 
 		// PostGroupImage 엔티티 리스트 생성
 		List<PostGroupImage> postGroupImages = request.getImageUrls().stream()

--- a/application/main-application/src/main/java/org/mainapplication/global/constants/PostGenerationCount.java
+++ b/application/main-application/src/main/java/org/mainapplication/global/constants/PostGenerationCount.java
@@ -1,0 +1,12 @@
+package org.mainapplication.global.constants;
+
+public final class PostGenerationCount {
+	private PostGenerationCount() {
+		throw new UnsupportedOperationException("인스턴스를 생성할 수 없습니다.");
+	}
+
+	// 한 번의 게시물 생성 시 생성되는 게시물 수, PostController에서 사용
+	public static final String POST_GENERATION_POST_COUNT = "5";
+	// 게시물 그룹 당 최대 게시물 생성 가능 횟수
+	public static final Integer MAX_POST_GENERATION_COUNT = 5;
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
@@ -101,6 +101,10 @@ public class PostGroup extends BaseTimeEntity {
 			.build();
 	}
 
+	public void increaseGenerationCount() {
+		this.generationCount++;
+	}
+
 	@Override
 	public String toString() {
 		return feed + "\n"

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
@@ -64,9 +64,11 @@ public class PostGroup extends BaseTimeEntity {
 	@Column(columnDefinition = "TEXT")
 	private String content;
 
+	private Integer generationCount;
+
 	@Builder
 	private PostGroup(Agent agent, RssFeed feed, String topic, PostGroupPurposeType purpose,
-		PostGroupReferenceType reference, PostGroupLengthType length, String content) {
+		PostGroupReferenceType reference, PostGroupLengthType length, String content, Integer generationCount) {
 		this.agent = agent;
 		this.topic = topic;
 		this.purpose = purpose;
@@ -74,6 +76,7 @@ public class PostGroup extends BaseTimeEntity {
 		this.feed = feed;
 		this.length = length;
 		this.content = content;
+		this.generationCount = generationCount;
 	}
 
 	public static PostGroup createPostGroup(
@@ -83,7 +86,8 @@ public class PostGroup extends BaseTimeEntity {
 		PostGroupPurposeType purpose,
 		PostGroupReferenceType reference,
 		PostGroupLengthType length,
-		String content
+		String content,
+		Integer generationCount
 	) {
 		return PostGroup.builder()
 			.agent(agent)
@@ -93,6 +97,7 @@ public class PostGroup extends BaseTimeEntity {
 			.reference(reference)
 			.length(length)
 			.content(content)
+			.generationCount(generationCount)
 			.build();
 	}
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #117 

## 📌 작업 내용 및 특이사항

### 1. 게시물 생성 횟수 제한 기능 추가
게시물 그룹별 게시물 생성 가능 횟수(25개)를 서버에서 제한하도록 기능을 추가했습니다. API 응답의 경우에는, 기존 뉴스 참고 게시물 생성 시 사용하던 eof를 확장하여 모든 생성 방식에서 eof를 유의미하게 사용할 수 있도록 수정했습니다. 따라서 25개를 넘지 않은 경우에는 false를, 25개가 채워진 경우에는 true를 응답하도록 구현했습니다.
- 이를 위해, PostGroup 엔티티에 generationCount 필드를 추가했습니다.
- 다음과 같이 생성 개수와 관련된 상수를 별도 클래스로 분리했습니다.
```java
public final class PostGenerationCount {
	// 한 번의 게시물 생성 시 생성되는 게시물 수, PostController에서 사용
	public static final String POST_GENERATION_POST_COUNT = "5";
	// 게시물 그룹 당 최대 게시물 생성 가능 횟수
	public static final Integer MAX_POST_GENERATION_COUNT = 5;
}
```

### 2. 그룹별 게시물 조회 API 응답 본문 수정
서버에서 생성 가능 횟수를 관리하기 때문에, 수정 화면에서 나갔다 다시 진입하는 경우 클라이언트에게 eof 정보를 응답해주어야 합니다. 따라서 해당 API 응답 본문에도 eof 필드를 추가하였습니다.

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
- 게시물 생성 횟수 검증 방식에 대해서, 당장은 게시물 개수(25개)가 아닌 게시물 생성 횟수(5번) 기준으로 검증하도록 구현했습니다. 현재 한 번에 5개씩 생성하는 정책이 바뀌지 않을 거라고 생각했고, 게시물 생성 중 예외가 발생하는 경우에도 게시물 자체는 5개 모두 생성되고 있기 때문에 횟수로 검증해도 문제가 없다고 생각했어요