### PR TITLE
[#122] Fix: Lambda 뉴스 본문 파싱 함수 호출 시의 타임아웃 문제 처리

### DIFF
--- a/inner-system/feed-client/src/main/java/org/feedclient/client/newsparser/NewsParserClient.java
+++ b/inner-system/feed-client/src/main/java/org/feedclient/client/newsparser/NewsParserClient.java
@@ -10,7 +10,10 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Component
+@Slf4j
 public class NewsParserClient {
 
 	private final RestClient newsParserClient;
@@ -27,9 +30,11 @@ public class NewsParserClient {
 			.body(new NewsParserRequest(newsUrl))
 			.retrieve()
 			.onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+				log.error("Client Error - {}: {}", res.getStatusText(), newsUrl);
 				throw new RuntimeException("Client error: " + res.getStatusCode());
 			})
 			.onStatus(HttpStatusCode::is5xxServerError, (req, res) -> {
+				log.error("Server Error - {}: {}", res.getStatusText(), newsUrl);
 				throw new RuntimeException("Server error: " + res.getStatusCode());
 			})
 			.body(NewsParserResponse.class);

--- a/inner-system/feed-client/src/main/java/org/feedclient/client/rss/type/RssItem.java
+++ b/inner-system/feed-client/src/main/java/org/feedclient/client/rss/type/RssItem.java
@@ -2,11 +2,13 @@ package org.feedclient.client.rss.type;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class RssItem {
 
 	private String id;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #122 

## 📌 작업 내용 및 특이사항

보통 3~4초 내외로 완료되는 뉴스 파싱 함수에서, 30초로 설정해둔 timeout이 간혹 초과되는 문제가 발생하는 것을 확인했습니다. (간혹 잘못된 페이지가 Rss 피드에 등록되고, 이 페이지를 파싱하는 과정에서 타임아웃이 발생하더라구요)

뿐만아니라 이 경우 애플리케이션 자체에서도 기존의 예외 처리가 부족해서, 파싱에 실패한 대로 게시물을 생성하는 단계로 넘어가야 하는데 전체 요청 자체가 에러로 응답되는 문제를 확인했습니다.

위 문제에 대해 트러블슈팅을 진행했습니다.

### 1. Lambda 함수 타임아웃 시간 조정
lambda에서 타임아웃을 포함한 에러가 발생할 경우, 정상 응답과 함께 애플리케이션에서 빈 본문값을 받도록 함수를 구현했었습니다. 하지만 현재 설정된 30초의 타임아웃 시간이 초과될 때 504 에러가 발생했고, 30초보다 짧은 시간으로 설정할 때는 타임아웃이 발생해도 504 에러가 응답되지 않았습니다. (해당 부분 정확한 원인은 계속해서 알아보겠습니다. 아마 lambda에 연결된 API Gateway의 타임아웃이지 않을까요? API Gateway의 기본 타임아웃이 29초라고 합니다.)

따라서 lambda 함수의 타임아웃 시간을 15초로 조정하였습니다.

### 2. 뉴스 파싱 관련 예외 처리
기존에는 뉴스 파싱 함수 호출 과정에서 에러가 응답될 경우 곧바로 클라이언트에 500 에러를 응답하도록 처리되어 있었습니다. 이때 파싱에 성공한 다른 뉴스들까지 사용하지 못하게 되는 문제가 발생하기 때문에, 에러가 발생한 경우 해당 뉴스 본문만 빈 문자열을 반환하도록 하여 나머지 게시물은 정상적으로 생성되도록 변경하였습니다.


## 📚 기타 / 관련 문서
- API Gateway 타임아웃
  - https://aws.amazon.com/ko/about-aws/whats-new/2017/11/customize-integration-timeouts-in-amazon-api-gateway/
  - https://aws.amazon.com/ko/about-aws/whats-new/2024/06/amazon-api-gateway-integration-timeout-limit-29-seconds/?nc1=h_ls