### PR TITLE
[#119] Feature: Tweet Post 업로드 시 Image와 함께 업로드

### DIFF
--- a/application/upload-schedule-application/src/main/java/org/uploadscheduleapplication/post/PostService.java
+++ b/application/upload-schedule-application/src/main/java/org/uploadscheduleapplication/post/PostService.java
@@ -4,7 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.domainmodule.post.entity.Post;
+import org.domainmodule.post.entity.PostImage;
 import org.domainmodule.post.entity.type.PostStatusType;
+import org.domainmodule.post.repository.PostImageRepository;
 import org.domainmodule.post.repository.PostRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PostService {
 	private final PostRepository postRepository;
+	private final PostImageRepository postImageRepository;
 
 	/**
 	 * @return 현재 시간의 분단위로 시간이 같은 Post들 반환
@@ -31,5 +34,13 @@ public class PostService {
 	public void updatePostStatus(Post post, PostStatusType postStatus) {
 		post.updateStatus(postStatus);
 		postRepository.save(post);
+	}
+
+	@Transactional
+	public List<String> getPostImageUrlsByPost(Post post) {
+		return postImageRepository.findAllByPost(post)
+			.stream()
+			.map(PostImage::getUrl)
+			.toList();
 	}
 }

--- a/application/upload-schedule-application/src/main/java/org/uploadscheduleapplication/service/UploadPostService.java
+++ b/application/upload-schedule-application/src/main/java/org/uploadscheduleapplication/service/UploadPostService.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 
 import org.domainmodule.post.entity.Post;
 import org.snsclient.twitter.service.TwitterApiService;
+import org.snsclient.twitter.service.TwitterMediaUploadService;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.uploadscheduleapplication.exception.TwitterUploadExceptionHandler;
@@ -20,9 +21,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UploadPostService {
 	private final TwitterApiService twitterApiService;
+	private final TwitterMediaUploadService twitterMediaUploadService;
 	private final PostService postService;
 	private final SnsTokenService snsTokenService;
 	private final TwitterUploadExceptionHandler uploadExceptionHandler;
+
 	private static final int MAX_RETRY_COUNT = 1;
 
 	/**
@@ -58,10 +61,20 @@ public class UploadPostService {
 			return CompletableFuture.completedFuture(null);
 		}
 		try {
+			List<String> imageUrls = postService.getPostImageUrlsByPost(uploadPostDto.post());
+
+			// 업로드 할 이미지 mediaID 리스트
+			Long[] mediaIds = imageUrls.stream()
+				.map(url -> twitterMediaUploadService.uploadMedia(url, uploadPostDto.snsToken().getAccessToken()))
+				.map(Long::parseLong)
+				.toArray(Long[]::new);
+
 			Long tweetId = twitterApiService.postTweet(
 				uploadPostDto.snsToken().getAccessToken(),
-				uploadPostDto.post().getContent()
+				uploadPostDto.post().getContent(),
+				mediaIds
 			);
+
 			uploadExceptionHandler.handleUploadSuccess(uploadPostDto, tweetId);
 			return CompletableFuture.completedFuture(null);
 		} catch (Exception ex) {

--- a/application/upload-schedule-application/src/main/java/org/uploadscheduleapplication/service/UploadPostService.java
+++ b/application/upload-schedule-application/src/main/java/org/uploadscheduleapplication/service/UploadPostService.java
@@ -64,7 +64,8 @@ public class UploadPostService {
 			List<String> imageUrls = postService.getPostImageUrlsByPost(uploadPostDto.post());
 
 			// 업로드 할 이미지 mediaID 리스트
-			Long[] mediaIds = imageUrls.stream()
+			Long[] mediaIds = imageUrls.isEmpty() ? null :
+				imageUrls.stream()
 				.map(url -> twitterMediaUploadService.uploadMedia(url, uploadPostDto.snsToken().getAccessToken()))
 				.map(Long::parseLong)
 				.toArray(Long[]::new);

--- a/inner-system/sns-client/build.gradle
+++ b/inner-system/sns-client/build.gradle
@@ -10,6 +10,8 @@ dependencies {
     // twitter
     api 'org.twitter4j:twitter4j-core:4.0.7'
     api 'io.github.takke:jp.takke.twitter4j-v2:1.4.4'
+
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/inner-system/sns-client/src/main/java/org/snsclient/twitter/config/WebClientConfig.java
+++ b/inner-system/sns-client/src/main/java/org/snsclient/twitter/config/WebClientConfig.java
@@ -1,0 +1,20 @@
+package org.snsclient.twitter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+	//TODO S3에서 이미지를 다운해서 multipart로 다시 넣어서 5MB로 늘려줬는데 괜찮을지
+	@Bean
+	public WebClient webClient() {
+		return WebClient.builder()
+			.defaultHeader("Content-Type", "multipart/form-data")
+			.codecs(configurer ->
+				configurer.defaultCodecs().maxInMemorySize(5 * 1024 * 1024) // 5MB로 증가
+			)
+			.build();
+	}
+}

--- a/inner-system/sns-client/src/main/java/org/snsclient/twitter/service/TwitterApiService.java
+++ b/inner-system/sns-client/src/main/java/org/snsclient/twitter/service/TwitterApiService.java
@@ -25,7 +25,7 @@ import twitter4j.conf.ConfigurationBuilder;
 @RequiredArgsConstructor
 public class TwitterApiService {
 	private final TwitterConfig config;
-	private final String[] scopes = {"tweet.read", "tweet.write", "users.read", "offline.access"};
+	private final String[] scopes = {"media.write", "tweet.read", "tweet.write", "users.read", "offline.access"};
 	private final OAuth2TokenProvider twitterOAuth2TokenProvider;
 
 	/**
@@ -153,9 +153,9 @@ public class TwitterApiService {
 	 * 트윗 생성 API 호출 메서드
 	 * @param content 트윗 내용
 	 */
-	public Long postTweet(String accessToken, String content) throws TwitterException {
+	public Long postTweet(String accessToken, String content, Long[] mediaIds) throws TwitterException {
 		TwitterV2 twitterV2 = createTwitterV2(accessToken);
-		CreateTweetResponse tweetResponse = twitterV2.createTweet(null, null, null, null, null, null, null, null, null, null, null, content);
+		CreateTweetResponse tweetResponse = twitterV2.createTweet(null, null, null, mediaIds, null, null, null, null, null, null, null, content);
 		return tweetResponse.getId();
 	}
 }

--- a/inner-system/sns-client/src/main/java/org/snsclient/twitter/service/TwitterMediaUploadService.java
+++ b/inner-system/sns-client/src/main/java/org/snsclient/twitter/service/TwitterMediaUploadService.java
@@ -1,0 +1,145 @@
+package org.snsclient.twitter.service;
+
+import java.util.ArrayList;
+
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TwitterMediaUploadService {
+
+	private final WebClient webClient;
+	private final ObjectMapper objectMapper;
+
+	private final String UPLOAD_URL = "https://api.x.com/2/media/upload";
+
+	/**
+	 * Presigned URL을 사용해 S3에서 이미지 다운로드 후 Twitter에 업로드
+	 */
+	public String uploadMedia(String presignedUrl, String accessToken) {
+		byte[] imageBytes = downloadImageFromS3(presignedUrl);
+		if (imageBytes == null || imageBytes.length == 0) {
+			throw new RuntimeException("이미지 다운로드 실패");
+		}
+
+		log.info("✅ S3에서 이미지 다운로드 완료 (크기: {} bytes)", imageBytes.length);
+
+		// INIT 요청 (업로드 준비 요청)
+		String initResponse = initUpload(imageBytes.length, accessToken);
+		String mediaId = extractMediaId(initResponse);
+
+		// APPEND 요청 (이미지 업로드)
+		appendMedia(mediaId, imageBytes, accessToken);
+
+		// FINALIZE 요청
+		String finalizeResponse = finalizeUpload(mediaId, accessToken);
+		return extractMediaId(finalizeResponse);
+	}
+
+	/**
+	 * WebClient로 S3에서 이미지 다운로드
+	 */
+	private byte[] downloadImageFromS3(String presignedUrl) {
+		return webClient.get()
+			.uri(presignedUrl)
+			.retrieve()
+			.bodyToMono(byte[].class) // 🔹 한 번에 byte[]로 변환
+			.block();
+	}
+
+	/**
+	 * INIT 요청 (미디어 업로드 세션 생성)
+	 */
+	private String initUpload(int totalBytes, String accessToken) {
+		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+		body.add("command", "INIT");
+		body.add("total_bytes", String.valueOf(totalBytes));
+		body.add("media_type", "image/jpeg");
+
+		return sendPostRequest(body, accessToken);
+	}
+
+	/**
+	 * APPEND 요청 (이미지 데이터 추가)
+	 */
+	private void appendMedia(String mediaId, byte[] imageBytes, String accessToken) {
+		MultipartBodyBuilder builder = new MultipartBodyBuilder();
+		builder.part("command", "APPEND");
+		builder.part("media_id", mediaId);
+		builder.part("segment_index", "0");
+		builder.part("media", new ByteArrayResource(imageBytes) {
+			@Override
+			public String getFilename() {
+				return "upload.jpg";
+			}
+		}).contentType(MediaType.IMAGE_JPEG);
+
+		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+		builder.build().forEach((key, value) -> body.put(key, new ArrayList<>(value)));
+
+		sendPostRequest(body, accessToken);
+	}
+
+	/**
+	 * FINALIZE 요청 (업로드 완료)
+	 */
+	private String finalizeUpload(String mediaId, String accessToken) {
+		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+		body.add("command", "FINALIZE");
+		body.add("media_id", mediaId);
+
+		return sendPostRequest(body, accessToken);
+	}
+
+	/**
+	 * Twitter API에 POST 요청을 보내고 media_id 추출
+	 */
+	private String sendPostRequest(MultiValueMap<String, Object> body, String accessToken) {
+		log.info("📢 Twitter API 요청: {}", body);
+
+		String response = webClient.post()
+			.uri(UPLOAD_URL)
+			.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+			.contentType(MediaType.MULTIPART_FORM_DATA)
+			.bodyValue(body)
+			.retrieve()
+			.bodyToMono(String.class)
+			.block();
+
+		log.info("✅ Twitter 응답: {}", response);
+
+		return response;
+	}
+
+	/**
+	 * 응답 JSON에서 media_id 추출
+	 */
+	private String extractMediaId(String responseBody) {
+		try {
+			JsonNode jsonNode = objectMapper.readTree(responseBody);
+			JsonNode dataNode = jsonNode.get("data");
+
+			if (dataNode != null && dataNode.has("id")) {
+				return dataNode.get("id").asText();
+			}
+			return null;
+		} catch (Exception e) {
+			log.error("Twitter 응답 JSON 파싱 실패", e);
+			throw new RuntimeException("Twitter 응답 JSON 파싱 실패", e);
+		}
+	}
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #119 

## 📌 작업 내용 및 특이사항
- WebClient를 이용해 Twitter Upload Media 요청 처리
- Post업로드시 Image와 함께 업로드 가능하도록 수정
- 업로드 플로우
1. INIT 옵션 요청으로 이미지 업로드 준비 ( Presigned URL처럼 미리 이미지의 mediaID값을 받아옴)
2. 업로드 예정인 Post에 S3 Image URL로 이미지 다운로드
3. multipart type으로 이미지 등록
4. APPEND 옵션 요청으로 이미지 실제 업로드 ( 실제로 이미지 등록)
5. FINALIZE 옵션 요청으로 업로드 확정
6. Post 업로드

## 🧐 고민한 점
- 이미지의 크기가 5MB 이상인 파일은 청크를 이용해 쪼개서 X에 업로드 해야함 (APPEND 옵션을 여러번 보내 작은단위로 업로드)
- 이미지 외에도 영상이나 gif 파일도 가능

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- [X API Media Upload 공식문서](https://docs.x.com/x-api/media/quickstart/media-upload-chunked)
- [노션에 간단하게 Media 등록 흐름 정리](https://living-stranger-3d0.notion.site/X-Media-193953d21bd4801fbff4d1f3ab2145a2?pvs=4)


