### PR TITLE
[#139] 프롬프트 내역 조회 API 수정

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/PromptHistoriesResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/PromptHistoriesResponse.java
@@ -40,7 +40,7 @@ public record PromptHistoriesResponse(
 	public static List<PromptHistoriesResponse> fromList(List<PromptHistory> histories) {
 		return histories.stream()
 			.map(PromptHistoriesResponse::from)
-			.collect(Collectors.toList());
+			.toList();
 	}
 }
 

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PromptHistoryService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PromptHistoryService.java
@@ -31,9 +31,6 @@ public class PromptHistoryService {
 		List<PromptHistory> histories = promptHistoryRepository.findPromptHistoriesWithValidation(userId, agentId,
 			postGroupId, postId);
 
-		if (histories.isEmpty()) {
-			throw new CustomException(PostErrorCode.PROMPT_HISTORIES_NOT_FOUND);
-		}
 		return PromptHistoriesResponse.fromList(histories);
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/global/response/GlobalResponseAdvice.java
+++ b/application/main-app/src/main/java/org/mainapp/global/response/GlobalResponseAdvice.java
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
 import jakarta.servlet.http.HttpServletResponse;
 
-@RestControllerAdvice(basePackages = "org.mainapplication")
+@RestControllerAdvice(basePackages = "org.mainapp")
 public class GlobalResponseAdvice implements ResponseBodyAdvice {
 
 	@Override


### PR DESCRIPTION
## 🌱 관련 이슈
- close #139 

## 📌 작업 내용 및 특이사항
- 프롬프트 기록이 없을 시 404 예외로 처리 -> 빈 리스트 반환하도록 수정
- 프론트에서 리스트가 없을 시 "내역 보기" 버튼 비활성화를 위해 수정했어요

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


