### PR TITLE
[#153] Feature: sns-client 패키지 구조 수정 및 sns 계정 AgentType 생성

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 # dev or prod
 SPRING_PROFILES_ACTIVE =
 
+SERVER_PORT=
+
 # DB
 MYSQL_HOST=localhost
 MYSQL_PORT=3306

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -37,12 +37,14 @@ public class AgentService {
 			AgentPlatformType.X,
 			userInfo.id(),
 			userInfo.description(),
-			userInfo.profileImageUrl());
+			userInfo.profileImageUrl(),
+			userInfo.subscriptionType()
+		);
 		return agentRepository.save(newAgent);
 	}
 
 	private Agent updatAgent(Agent agent, TwitterUserInfoDto userInfo) {
-		agent.updateInfo(userInfo.description(), userInfo.profileImageUrl());
+		agent.updateInfo(userInfo.description(), userInfo.profileImageUrl(), userInfo.subscriptionType());
 		return agentRepository.save(agent);
 	}
 }

--- a/application/schedule-app/src/main/java/org/scheduleapp/schedule/UploadPostService.java
+++ b/application/schedule-app/src/main/java/org/scheduleapp/schedule/UploadPostService.java
@@ -15,13 +15,13 @@ import org.scheduleapp.util.dto.UploadPostDto;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import twitter4j.TwitterException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class UploadPostService {
 	private final TwitterApiService twitterApiService;
-	private final TwitterMediaUploadService twitterMediaUploadService;
 	private final PostService postService;
 	private final SnsTokenService snsTokenService;
 	private final TwitterUploadExceptionHandler uploadExceptionHandler;
@@ -66,7 +66,13 @@ public class UploadPostService {
 			// 업로드 할 이미지 mediaID 리스트
 			Long[] mediaIds = imageUrls.isEmpty() ? null :
 				imageUrls.stream()
-				.map(url -> twitterMediaUploadService.uploadMedia(url, uploadPostDto.snsToken().getAccessToken()))
+				.map(url -> {
+					try {
+						return twitterApiService.uploadMedia(url, uploadPostDto.snsToken().getAccessToken());
+					} catch (TwitterException e) {
+						throw new RuntimeException("Media 업로드에 실패하였습니다.", e);
+					}
+				})
 				.map(Long::parseLong)
 				.toArray(Long[]::new);
 

--- a/application/schedule-app/src/main/java/org/scheduleapp/snstoken/SnsTokenService.java
+++ b/application/schedule-app/src/main/java/org/scheduleapp/snstoken/SnsTokenService.java
@@ -3,7 +3,7 @@ package org.scheduleapp.snstoken;
 import org.domainmodule.snstoken.entity.SnsToken;
 import org.domainmodule.snstoken.repository.SnsTokenRepository;
 import org.snsclient.twitter.dto.response.TwitterToken;
-import org.snsclient.twitter.service.TwitterApiService;
+import org.snsclient.twitter.service.Twitter4jService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.scheduleapp.util.dto.UploadPostDto;
@@ -14,7 +14,7 @@ import twitter4j.TwitterException;
 @Service
 @RequiredArgsConstructor
 public class SnsTokenService {
-	private final TwitterApiService twitterApiService;
+	private final Twitter4jService twitter4JService;
 	private final SnsTokenRepository snsTokenRepository;
 
 	@Transactional
@@ -41,7 +41,7 @@ public class SnsTokenService {
 
 	private TwitterToken refreshSnsToken(String refreshToken) {
 		try {
-			return twitterApiService.refreshTwitterToken(refreshToken);
+			return twitter4JService.refreshTwitterToken(refreshToken);
 		} catch (TwitterException e) {
 			throw new RuntimeException("Twitter 토큰 재발급에 실패하였습니다.", e);
 		}

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/client/TwitterRestClient.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/client/TwitterRestClient.java
@@ -1,0 +1,77 @@
+package org.snsclient.twitter.client;
+
+import java.net.URI;
+
+import org.snsclient.twitter.dto.response.TwitterUserInfoDto;
+import org.snsclient.twitter.dto.response.TwitterUserResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import twitter4j.TwitterException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TwitterRestClient {
+	private final WebClient webClient;
+
+	/**
+	 * Twitter API에 Media Upload 요청
+	 */
+	public String postMediaRequest(MultiValueMap<String, Object> body, String accessToken, String url) throws
+		TwitterException {
+		try {
+			return webClient.post()
+				.uri(URI.create(url))
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.contentType(MediaType.MULTIPART_FORM_DATA)
+				.bodyValue(body)
+				.retrieve()
+				.bodyToMono(String.class)
+				.block();
+
+		} catch (Exception e) {
+			log.error("Twitter Media 업로드 요청 중 에러 발생", e);
+			throw new TwitterException("Twitter Media 업로드 요청 중 에러 발생: " + e.getMessage(), e);
+		}
+	}
+
+	public TwitterUserInfoDto getUserGetMeRequest(String userFields, String accessToken, String url) throws
+		TwitterException {
+		try {
+			URI uri = UriComponentsBuilder.fromHttpUrl(url)
+				.queryParam("user.fields", userFields)
+				.build()
+				.encode()
+				.toUri();
+			TwitterUserResponse response = webClient.get()
+				.uri(uri)
+				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+				.retrieve()
+				.bodyToMono(TwitterUserResponse.class)
+				.block();
+
+			return response.data(); // 내부 "data" 객체만 반환
+		} catch (Exception e) {
+			log.error("Twitter 사용자 정보 요청 중 에러 발생", e);
+			throw new TwitterException("Twitter 사용자 정보 요청 중 에러 발생: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * S3에서 이미지 다운로드
+	 */
+	public byte[] downloadImageFromS3(String presignedUrl) {
+		return webClient.get()
+			.uri(presignedUrl)
+			.retrieve()
+			.bodyToMono(byte[].class)
+			.block();
+	}
+}

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/config/Twitter4jConfig.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/config/Twitter4jConfig.java
@@ -10,7 +10,7 @@ import twitter4j.conf.ConfigurationBuilder;
 
 @Getter
 @Configuration
-public class TwitterConfig {
+public class Twitter4jConfig {
 	@Value("${sns.twitter.client-id}")
 	private String clientId;
 

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/config/WebClientConfig.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/config/WebClientConfig.java
@@ -11,7 +11,6 @@ public class WebClientConfig {
 	@Bean
 	public WebClient webClient() {
 		return WebClient.builder()
-			.defaultHeader("Content-Type", "multipart/form-data")
 			.codecs(configurer ->
 				configurer.defaultCodecs().maxInMemorySize(5 * 1024 * 1024) // 5MB로 증가
 			)

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/dto/response/TwitterUserInfoDto.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/dto/response/TwitterUserInfoDto.java
@@ -1,22 +1,14 @@
 package org.snsclient.twitter.dto.response;
 
-import twitter4j.User2;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public record TwitterUserInfoDto(
-	String id,
-	String accountId,
-	String name,
-	String description,
-	String profileImageUrl
-) {
-
-	public static TwitterUserInfoDto fromTwitterUser(User2 user) {
-		return new TwitterUserInfoDto(
-			String.valueOf(user.getId()),
-			user.getScreenName(),
-			user.getName(),
-			user.getDescription(),
-			user.getProfileImageUrl()
-		);
-	}
-}
+	@JsonProperty("description") String description,
+	@JsonProperty("subscription_type") String subscriptionType,
+	@JsonProperty("username") String username,
+	@JsonProperty("name") String name,
+	@JsonProperty("profile_image_url") String profileImageUrl,
+	@JsonProperty("id") String id
+) {}

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/dto/response/TwitterUserResponse.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/dto/response/TwitterUserResponse.java
@@ -1,0 +1,9 @@
+package org.snsclient.twitter.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TwitterUserResponse(
+	@JsonProperty("data") TwitterUserInfoDto data
+) {}

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/service/Twitter4jService.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/service/Twitter4jService.java
@@ -1,0 +1,140 @@
+package org.snsclient.twitter.service;
+
+import org.snsclient.twitter.config.Twitter4jConfig;
+import org.snsclient.twitter.dto.response.TwitterToken;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import twitter4j.CreateTweetResponse;
+import twitter4j.OAuth2TokenProvider;
+import twitter4j.Twitter;
+import twitter4j.TwitterException;
+import twitter4j.TwitterFactory;
+import twitter4j.TwitterV2;
+import twitter4j.TwitterV2ExKt;
+import twitter4j.auth.OAuth2Authorization;
+import twitter4j.auth.OAuth2Token;
+import twitter4j.conf.Configuration;
+import twitter4j.conf.ConfigurationBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class Twitter4jService {
+	private final Twitter4jConfig config;
+	private final String[] scopes = {"media.write", "tweet.read", "tweet.write", "users.read", "offline.access"};
+	private final OAuth2TokenProvider twitterOAuth2TokenProvider;
+
+	/**
+	 * authorization url 생성 메서드
+	 * @return authorization url
+	 */
+	public String getTwitterAuthorizationUrl() {
+		return twitterOAuth2TokenProvider.createAuthorizeUrl(
+			config.getClientId(),
+			config.getRedirectUri(),
+			scopes,
+			config.getChallenge());
+	}
+
+	/**
+	 * 발급받은 code를 가지고 access token(2시간 동안 유효)을 발급받는 메서드
+	 * @param code 발급받은 code (10분간 유효)
+	 * @return access token
+	 */
+	public TwitterToken getTwitterAuthorizationToken(String code) {
+		try {
+			OAuth2TokenProvider.Result result = twitterOAuth2TokenProvider.getAccessToken(
+				config.getClientId(),
+				config.getRedirectUri(),
+				code,
+				config.getChallenge()
+			);
+
+			validateTokenResult(result);
+
+			return TwitterToken.of(
+				result.getAccessToken(),
+				result.getRefreshToken(),
+				result.getExpiresIn()
+			);
+		} catch (Exception e) {
+			log.error("Twitter Token 발급 API 호출 중 오류 발생: {}", e.getMessage());
+			throw new RuntimeException("Twitter Token 발급 API 호출 중 오류 발생", e);
+		}
+	}
+
+	private void validateTokenResult(OAuth2TokenProvider.Result result) {
+		if (result == null) {
+			throw new IllegalStateException("Twitter OAuth2TokenProvider 값이 존재하지 않습니다.");
+		}
+		validateRefreshTokenProcess(result);
+	}
+
+	private boolean isNullOrBlank(String value) {
+		return value == null || value.isBlank();
+	}
+
+	/**
+	 * TwitterV2 클라이언트 인스턴스를 생성해 반환하는 메서드
+	 * @param accessToken accessToken
+	 * @return TwitterV2 인스턴스
+	 */
+	private TwitterV2 createTwitterV2(String accessToken) throws TwitterException {
+		try {
+			Configuration configuration = new ConfigurationBuilder()
+				.setOAuthConsumerKey(config.getClientId())
+				.setOAuthConsumerSecret(config.getClientSecret())
+				.build();
+
+			OAuth2Authorization auth = new OAuth2Authorization(configuration);
+			auth.setOAuth2Token(new OAuth2Token("bearer", accessToken));
+
+			Twitter twitter = new TwitterFactory(configuration).getInstance(auth);
+
+			return TwitterV2ExKt.getV2(twitter);
+		} catch (Exception e) {
+			log.error("TwitterV2 클라이언트 생성 중 오류 발생: {}", e.getMessage());
+			throw new TwitterException("TwitterV2 클라이언트 생성 중 오류 발생", e);
+		}
+	}
+
+	/**
+	 * 토큰 만료 시 RefreshToken으로 AccessToken 갱신
+	 * @param refreshToken 기존 Twitter RefreshToken
+	 */
+	public TwitterToken refreshTwitterToken(String refreshToken) throws TwitterException {
+		try {
+			final String clientId = config.getClientId();
+			OAuth2TokenProvider.Result result = twitterOAuth2TokenProvider.refreshToken(clientId, refreshToken);
+			validateRefreshTokenProcess(result);
+			return TwitterToken.of(result.getAccessToken(), result.getRefreshToken(), result.getExpiresIn());
+		} catch (Exception e) {
+			log.error("Twitter Token 재발급 호출 중 오류 발생: {}", e.getMessage());
+			throw new TwitterException("Twitter RefreshToken 갱신 중 오류 발생", e);
+		}
+	}
+
+	private void validateRefreshTokenProcess(OAuth2TokenProvider.Result result) {
+		if (result == null) {
+			throw new IllegalStateException("OAuth2TokenProvider 값이 존재하지 않습니다.");
+		}
+		if (isNullOrBlank(result.getAccessToken())) {
+			throw new IllegalArgumentException("Twitter AccessToken 발급에 실패하였습니다.");
+		}
+		if (isNullOrBlank(result.getRefreshToken())) {
+			throw new IllegalArgumentException("Twitter RefreshToken 발급에 실패하였습니다.");
+		}
+	}
+
+	/**
+	 * 트윗 생성 API 호출 메서드
+	 * @param content 트윗 내용
+	 */
+	public Long postTweet(String accessToken, String content, Long[] mediaIds) throws TwitterException {
+		TwitterV2 twitterV2 = createTwitterV2(accessToken);
+		CreateTweetResponse tweetResponse = twitterV2.createTweet(null, null, null, mediaIds, null, null, null, null, null, null, null, content);
+		return tweetResponse.getId();
+	}
+}

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterApiService.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterApiService.java
@@ -1,161 +1,61 @@
 package org.snsclient.twitter.service;
 
-import org.snsclient.twitter.config.TwitterConfig;
 import org.snsclient.twitter.dto.response.TwitterToken;
 import org.snsclient.twitter.dto.response.TwitterUserInfoDto;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import twitter4j.CreateTweetResponse;
-import twitter4j.OAuth2TokenProvider;
-import twitter4j.Twitter;
 import twitter4j.TwitterException;
-import twitter4j.TwitterFactory;
-import twitter4j.TwitterV2;
-import twitter4j.TwitterV2ExKt;
-import twitter4j.UsersResponse;
-import twitter4j.auth.OAuth2Authorization;
-import twitter4j.auth.OAuth2Token;
-import twitter4j.conf.Configuration;
-import twitter4j.conf.ConfigurationBuilder;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TwitterApiService {
-	private final TwitterConfig config;
-	private final String[] scopes = {"media.write", "tweet.read", "tweet.write", "users.read", "offline.access"};
-	private final OAuth2TokenProvider twitterOAuth2TokenProvider;
+	private final TwitterGetMeService twitterGetMeService;
+	private final TwitterMediaUploadService twitterMediaUploadService;
+	private final Twitter4jService twitter4jService;
+
 
 	/**
 	 * authorization url 생성 메서드
-	 * @return authorization url
 	 */
 	public String getTwitterAuthorizationUrl() {
-		return twitterOAuth2TokenProvider.createAuthorizeUrl(
-			config.getClientId(),
-			config.getRedirectUri(),
-			scopes,
-			config.getChallenge());
+		return twitter4jService.getTwitterAuthorizationUrl();
 	}
 
 	/**
 	 * 발급받은 code를 가지고 access token(2시간 동안 유효)을 발급받는 메서드
-	 * @param code 발급받은 code (10분간 유효)
-	 * @return access token
 	 */
 	public TwitterToken getTwitterAuthorizationToken(String code) {
-		try {
-			OAuth2TokenProvider.Result result = twitterOAuth2TokenProvider.getAccessToken(
-				config.getClientId(),
-				config.getRedirectUri(),
-				code,
-				config.getChallenge()
-			);
-
-			validateTokenResult(result);
-
-			return TwitterToken.of(
-				result.getAccessToken(),
-				result.getRefreshToken(),
-				result.getExpiresIn()
-			);
-		} catch (Exception e) {
-			log.error("Twitter Token 발급 API 호출 중 오류 발생: {}", e.getMessage());
-			throw new RuntimeException("Twitter Token 발급 API 호출 중 오류 발생", e);
-		}
-	}
-
-	private void validateTokenResult(OAuth2TokenProvider.Result result) {
-		if (result == null) {
-			throw new IllegalStateException("Twitter OAuth2TokenProvider 값이 존재하지 않습니다.");
-		}
-		validateRefreshTokenProcess(result);
-	}
-
-	private boolean isNullOrBlank(String value) {
-		return value == null || value.isBlank();
-	}
-
-	/**
-	 * TwitterV2 클라이언트 인스턴스를 생성해 반환하는 메서드
-	 * @param accessToken accessToken
-	 * @return TwitterV2 인스턴스
-	 */
-	private TwitterV2 createTwitterV2(String accessToken) throws TwitterException {
-		try {
-			Configuration configuration = new ConfigurationBuilder()
-				.setOAuthConsumerKey(config.getClientId())
-				.setOAuthConsumerSecret(config.getClientSecret())
-				.build();
-
-			OAuth2Authorization auth = new OAuth2Authorization(configuration);
-			auth.setOAuth2Token(new OAuth2Token("bearer", accessToken));
-
-			Twitter twitter = new TwitterFactory(configuration).getInstance(auth);
-
-			return TwitterV2ExKt.getV2(twitter);
-		} catch (Exception e) {
-			log.error("TwitterV2 클라이언트 생성 중 오류 발생: {}", e.getMessage());
-			throw new TwitterException("TwitterV2 클라이언트 생성 중 오류 발생", e);
-		}
+		return twitter4jService.getTwitterAuthorizationToken(code);
 	}
 
 	/**
 	 * 토큰 만료 시 RefreshToken으로 AccessToken 갱신
-	 * @param refreshToken 기존 Twitter RefreshToken
 	 */
 	public TwitterToken refreshTwitterToken(String refreshToken) throws TwitterException {
-		try {
-			final String clientId = config.getClientId();
-			OAuth2TokenProvider.Result result = twitterOAuth2TokenProvider.refreshToken(clientId, refreshToken);
-			validateRefreshTokenProcess(result);
-			return TwitterToken.of(result.getAccessToken(), result.getRefreshToken(), result.getExpiresIn());
-		} catch (Exception e) {
-			log.error("Twitter Token 재발급 호출 중 오류 발생: {}", e.getMessage());
-			throw new TwitterException("Twitter RefreshToken 갱신 중 오류 발생", e);
-		}
-	}
-
-	private void validateRefreshTokenProcess(OAuth2TokenProvider.Result result) {
-		if (result == null) {
-			throw new IllegalStateException("OAuth2TokenProvider 값이 존재하지 않습니다.");
-		}
-		if (isNullOrBlank(result.getAccessToken())) {
-			throw new IllegalArgumentException("Twitter AccessToken 발급에 실패하였습니다.");
-		}
-		if (isNullOrBlank(result.getRefreshToken())) {
-			throw new IllegalArgumentException("Twitter RefreshToken 발급에 실패하였습니다.");
-		}
-	}
-
-	/**
-	 * X로 부터 유저 본인의 정보 받아오기 (401시 토큰 재발급 후 요청)
-	 * @param accessToken
-	 * @return 트위터 유저 기본 정보
-	 */
-	public TwitterUserInfoDto getUserInfo(String accessToken) throws TwitterException {
-		TwitterV2 twitterV2 = createTwitterV2(accessToken);
-		UsersResponse usersResponse = twitterV2.getMe("", null, "description,profile_image_url");
-		return mapToUserInfoDto(usersResponse);
-	}
-
-	private TwitterUserInfoDto mapToUserInfoDto(UsersResponse usersResponse) throws TwitterException {
-		return usersResponse.getUsers()
-			.stream()
-			.findFirst()  //twitter.getMe가 여러 유저를 리턴가능하기에 설정
-			.map(TwitterUserInfoDto::fromTwitterUser)
-			.orElseThrow(() -> new TwitterException("X 유저 정보가 없습니다."));
+		return twitter4jService.refreshTwitterToken(refreshToken);
 	}
 
 	/**
 	 * 트윗 생성 API 호출 메서드
-	 * @param content 트윗 내용
 	 */
 	public Long postTweet(String accessToken, String content, Long[] mediaIds) throws TwitterException {
-		TwitterV2 twitterV2 = createTwitterV2(accessToken);
-		CreateTweetResponse tweetResponse = twitterV2.createTweet(null, null, null, mediaIds, null, null, null, null, null, null, null, content);
-		return tweetResponse.getId();
+		return twitter4jService.postTweet(accessToken, content, mediaIds);
+	}
+
+	/**
+	 * Twitter 미디어 업로드
+	 */
+	public String uploadMedia(String presignedUrl, String accessToken) throws TwitterException {
+		return twitterMediaUploadService.uploadMedia(presignedUrl, accessToken);
+	}
+
+	/**
+	 * X로 부터 유저 본인의 정보 받아오기
+	 */
+	public TwitterUserInfoDto getUserInfo(String accessToken) throws TwitterException {
+		return twitterGetMeService.getUserInfo(accessToken);
 	}
 }

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterGetMeService.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterGetMeService.java
@@ -1,0 +1,28 @@
+package org.snsclient.twitter.service;
+
+import org.snsclient.twitter.client.TwitterRestClient;
+import org.snsclient.twitter.dto.response.TwitterUserInfoDto;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import twitter4j.TwitterException;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TwitterGetMeService {
+
+	private final TwitterRestClient twitterRestClient;
+
+	private final String TWITTER_GET_ME_URL = "https://api.x.com/2/users/me";
+
+	/**
+	 * X로 부터 유저 본인의 정보 받아오기
+	 * @param accessToken
+	 * @return 트위터 유저 기본 정보
+	 */
+	public TwitterUserInfoDto getUserInfo(String accessToken) throws TwitterException {
+		return twitterRestClient.getUserGetMeRequest("description,profile_image_url,subscription_type", accessToken, TWITTER_GET_ME_URL);
+	}
+}

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterMediaUploadService.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterMediaUploadService.java
@@ -2,36 +2,36 @@ package org.snsclient.twitter.service;
 
 import java.util.ArrayList;
 
+import org.snsclient.twitter.client.TwitterRestClient;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.MultipartBodyBuilder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import twitter4j.TwitterException;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class TwitterMediaUploadService {
 
-	private final WebClient webClient;
 	private final ObjectMapper objectMapper;
+	private final TwitterRestClient twitterRestClient;
 
-	private final String UPLOAD_URL = "https://api.x.com/2/media/upload";
+	private final String TWITTER_MEDIA_UPLOAD_URL = "https://api.x.com/2/media/upload";
 
 	/**
-	 * Presigned URL을 사용해 S3에서 이미지 다운로드 후 Twitter에 업로드
+	 * Presigned URL을 사용해 S3에서 이미지 다운로드 후 Twitter에 이미지 업로드
 	 */
-	public String uploadMedia(String presignedUrl, String accessToken) {
-		byte[] imageBytes = downloadImageFromS3(presignedUrl);
+	public String uploadMedia(String presignedUrl, String accessToken) throws TwitterException {
+		byte[] imageBytes = twitterRestClient.downloadImageFromS3(presignedUrl);
 		if (imageBytes == null || imageBytes.length == 0) {
 			throw new RuntimeException("이미지 다운로드 실패");
 		}
@@ -51,32 +51,21 @@ public class TwitterMediaUploadService {
 	}
 
 	/**
-	 * WebClient로 S3에서 이미지 다운로드
-	 */
-	private byte[] downloadImageFromS3(String presignedUrl) {
-		return webClient.get()
-			.uri(presignedUrl)
-			.retrieve()
-			.bodyToMono(byte[].class)
-			.block();
-	}
-
-	/**
 	 * INIT 요청 (미디어 업로드 세션 생성)
 	 */
-	private String initUpload(int totalBytes, String accessToken) {
+	private String initUpload(int totalBytes, String accessToken) throws TwitterException {
 		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 		body.add("command", "INIT");
 		body.add("total_bytes", String.valueOf(totalBytes));
 		body.add("media_type", "image/jpeg");
 
-		return sendPostRequest(body, accessToken);
+		return twitterRestClient.postMediaRequest(body, accessToken, TWITTER_MEDIA_UPLOAD_URL);
 	}
 
 	/**
 	 * APPEND 요청 (이미지 데이터 추가)
 	 */
-	private void appendMedia(String mediaId, byte[] imageBytes, String accessToken) {
+	private void appendMedia(String mediaId, byte[] imageBytes, String accessToken) throws TwitterException {
 		MultipartBodyBuilder builder = new MultipartBodyBuilder();
 		builder.part("command", "APPEND");
 		builder.part("media_id", mediaId);
@@ -93,43 +82,18 @@ public class TwitterMediaUploadService {
 			(key, value) -> body.put(key, new ArrayList<>(value))
 		);
 
-		sendPostRequest(body, accessToken);
+		twitterRestClient.postMediaRequest(body, accessToken, TWITTER_MEDIA_UPLOAD_URL);
 	}
 
 	/**
 	 * FINALIZE 요청 (업로드 완료)
 	 */
-	private String finalizeUpload(String mediaId, String accessToken) {
+	private String finalizeUpload(String mediaId, String accessToken) throws TwitterException {
 		MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
 		body.add("command", "FINALIZE");
 		body.add("media_id", mediaId);
 
-		return sendPostRequest(body, accessToken);
-	}
-
-	/**
-	 * Twitter API에 POST 요청을 보내고 media_id 추출
-	 */
-	private String sendPostRequest(MultiValueMap<String, Object> body, String accessToken) {
-		log.info("📢 Twitter API 요청: {}", body);
-
-		try {
-			String response = webClient.post()
-				.uri(UPLOAD_URL)
-				.header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-				.contentType(MediaType.MULTIPART_FORM_DATA)
-				.bodyValue(body)
-				.retrieve()
-				.bodyToMono(String.class)
-				.block();
-
-			log.info("✅ Twitter 응답: {}", response);
-
-			return response;
-		} catch (Exception e) {
-			log.error("Twitter Media Upload 요청 중 에러 발생", e);
-			throw new RuntimeException("Twitter Media Upload 요청 중 에러 발생: " + e.getMessage(), e);
-		}
+		return twitterRestClient.postMediaRequest(body, accessToken, TWITTER_MEDIA_UPLOAD_URL);
 	}
 
 	/**

--- a/clients/sns-client/src/test/java/org/snsclient/twitter/service/Twitter4JServiceTest.java
+++ b/clients/sns-client/src/test/java/org/snsclient/twitter/service/Twitter4JServiceTest.java
@@ -3,7 +3,7 @@ package org.snsclient.twitter.service;
 
 import org.junit.jupiter.api.Test;
 
-class TwitterApiServiceTest {
+class Twitter4JServiceTest {
 
 
 	@Test

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
@@ -68,7 +68,8 @@ public class Agent extends BaseTimeEntity {
 		AgentPlatformType agentPlatform,
 		String accountId,
 		String bio,
-		String profileImage
+		String profileImage,
+		AgentType agentType
 	) {
 		this.user = user;
 		this.platform = agentPlatform;
@@ -76,7 +77,7 @@ public class Agent extends BaseTimeEntity {
 		this.bio = bio;
 		this.profileImage = profileImage;
 		this.autoMode = Boolean.FALSE;
-		this.agentType = AgentType.BASIC;
+		this.agentType = agentType;
 		this.isActivated = Boolean.TRUE;
 	}
 
@@ -85,21 +86,27 @@ public class Agent extends BaseTimeEntity {
 		AgentPlatformType agentPlatform,
 		String accountId,
 		String bio,
-		String profileImage) {
+		String profileImage,
+		String subscriptionType
+	) {
 		return Agent.builder()
 			.user(user)
 			.agentPlatform(agentPlatform)
 			.accountId(accountId)
 			.bio(bio)
 			.profileImage(profileImage)
+			.agentType(AgentType.fromSubscription(subscriptionType))
 			.build();
 	}
 
 	public void updateInfo(
 		String bio,
-		String profileImage
+		String profileImage,
+		String agentType
+
 	) {
 		this.bio = bio;
 		this.profileImage = profileImage;
+		this.agentType = AgentType.fromSubscription(agentType);
 	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentType.java
@@ -1,5 +1,14 @@
 package org.domainmodule.agent.entity.type;
 
 public enum AgentType {
-	BASIC, PREMIUM
+	BASIC, PREMIUM;
+	public static AgentType fromSubscription(String subscriptionType) {
+		if (subscriptionType == null) {
+			return BASIC;
+		}
+		return switch (subscriptionType.toUpperCase()) {
+			case "PREMIUM" -> PREMIUM;
+			default -> BASIC;
+		};
+	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentType.java
@@ -1,14 +1,16 @@
 package org.domainmodule.agent.entity.type;
 
 public enum AgentType {
-	BASIC, PREMIUM;
+	FREE, BASIC, PREMIUM, PREMIUM_PLUS ;
 	public static AgentType fromSubscription(String subscriptionType) {
 		if (subscriptionType == null) {
-			return BASIC;
+			return FREE;
 		}
 		return switch (subscriptionType.toUpperCase()) {
+			case "BASIC" -> BASIC;
 			case "PREMIUM" -> PREMIUM;
-			default -> BASIC;
+			case "PREMIUMPLUS" -> PREMIUM_PLUS;
+			default -> FREE;
 		};
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #153 

## 📌 작업 내용 및 특이사항
- sns-client 패키지 facade패턴 이용 (TwitterApiService로 호출) - TwitterGeMeService + Twitter4JService + TwitterMediaUploadService
- env.example에 SERVER_PORT 추가
- Twitter에서 String값인 subscription_type을 받아 AgentType ENum값으로 매핑
```java
public enum AgentType {
	BASIC, PREMIUM;
	public static AgentType fromSubscription(String subscriptionType) {
		if (subscriptionType == null) {
			return BASIC;
		}
		return switch (subscriptionType.toUpperCase()) {
			case "PREMIUM" -> PREMIUM;
			default -> BASIC;
		};
	}
}
```
기본값으로 BASIC 설정

트위터에서 리턴되는 값 예시:
    - "Basic": 기본 유료 구독
    - "Premium": 프리미엄 유료 구독
    - "PremiumPlus": 프리미엄 플러스 유료 구독
    - "None": 무료 계정
## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


