### PR TITLE
[#155] Feature: SecurityUtil에서 요청한 사용자 userId값 불러오기

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/auth/exception/AuthErrorCode.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,18 @@
+package org.mainapp.domain.auth.exception;
+
+import org.mainapp.global.error.ErrorCodeStatus;
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCodeStatus {
+	// 인증 에러
+	UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
+	TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "세션이 만료되었습니다."),
+	AUTH_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "인증 정보를 찾을 수 없습니다.");
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostPromptHistoryService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostPromptHistoryService.java
@@ -7,8 +7,7 @@ import org.domainmodule.post.entity.PromptHistory;
 import org.domainmodule.post.entity.type.PostPromptType;
 import org.domainmodule.post.repository.PromptHistoryRepository;
 import org.mainapp.domain.post.controller.response.PromptHistoriesResponse;
-import org.mainapp.domain.post.exception.PostErrorCode;
-import org.mainapp.global.error.CustomException;
+import org.mainapp.global.util.SecurityUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,8 +24,7 @@ public class PostPromptHistoryService {
 	 */
 	@Transactional(readOnly = true)
 	public List<PromptHistoriesResponse> getPromptHistories(Long agentId, Long postGroupId, Long postId) {
-		//TODO 임시 설정한 부분 (이후 securityContext에서 userId가져오기)
-		long userId = 1L;
+		final long userId = Long.parseLong(SecurityUtil.getCurrentMemberId());
 
 		List<PromptHistory> histories = promptHistoryRepository.findPromptHistoriesWithValidation(userId, agentId,
 			postGroupId, postId);

--- a/application/main-app/src/main/java/org/mainapp/domain/token/service/TokenServiceImpl.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/token/service/TokenServiceImpl.java
@@ -55,7 +55,7 @@ public class TokenServiceImpl implements TokenService {
 
 	private void createAndSaveRefreshToken(Long userId, String token) {
 		User user = userService.findUserById(userId);
-		RefreshToken refreshToken = RefreshToken.create(user, token, Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMS()).toSeconds());
+		RefreshToken refreshToken = RefreshToken.create(user, token, Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs()).toSeconds());
 		refreshTokenRepository.save(refreshToken);
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/global/config/JwtConfig.java
+++ b/application/main-app/src/main/java/org/mainapp/global/config/JwtConfig.java
@@ -1,0 +1,10 @@
+package org.mainapp.global.config;
+
+import org.mainapp.global.constants.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtConfig {
+}

--- a/application/main-app/src/main/java/org/mainapp/global/constants/JwtProperties.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/JwtProperties.java
@@ -1,6 +1,7 @@
 package org.mainapp.global.constants;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.stereotype.Component;
 
 import lombok.Getter;
@@ -9,10 +10,11 @@ import lombok.Setter;
 @Getter
 @Setter
 @Component
+@ConfigurationPropertiesScan
 @ConfigurationProperties(prefix = "jwt")
 public class JwtProperties {
-	private long accessTokenExpirationMS;
-	private long refreshTokenExpirationMS;
+	private long accessTokenExpirationMs;
+	private long refreshTokenExpirationMs;
 	private String accessTokenKey;
 	private String refreshTokenKey;
 }

--- a/application/main-app/src/main/java/org/mainapp/global/util/JwtUtil.java
+++ b/application/main-app/src/main/java/org/mainapp/global/util/JwtUtil.java
@@ -40,7 +40,7 @@ public class JwtUtil {
 				.setSubject(userId)
 				.setIssuer(ISSUER)
 				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + jwtProperties.getAccessTokenExpirationMS()))
+				.setExpiration(new Date(now.getTime() + jwtProperties.getAccessTokenExpirationMs()))
 				.signWith(getAccessTokenKey(), SignatureAlgorithm.HS256)
 				.compact();
 	}
@@ -53,7 +53,7 @@ public class JwtUtil {
 				.setSubject(userId)
 				.setIssuer(ISSUER)
 				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + jwtProperties.getRefreshTokenExpirationMS()))
+				.setExpiration(new Date(now.getTime() + jwtProperties.getRefreshTokenExpirationMs()))
 				.signWith(getRefreshTokenKey(), SignatureAlgorithm.HS256)
 				.compact();
 	}

--- a/application/main-app/src/main/java/org/mainapp/global/util/ResponseUtil.java
+++ b/application/main-app/src/main/java/org/mainapp/global/util/ResponseUtil.java
@@ -21,7 +21,7 @@ public class ResponseUtil {
 	}
 
 	private void createHttpOnlyCookie(HttpServletResponse response, String refreshToken) {
-		long refreshTokenExpirationSC = Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMS()).toSeconds();
+		long refreshTokenExpirationSC = Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs()).toSeconds();
 
 		Cookie cookie = new Cookie(HeaderConstants.REFRESH_TOKEN_HEADER, refreshToken);
 		cookie.setHttpOnly(true);

--- a/application/main-app/src/main/java/org/mainapp/global/util/SecurityUtil.java
+++ b/application/main-app/src/main/java/org/mainapp/global/util/SecurityUtil.java
@@ -4,9 +4,7 @@ import org.mainapp.domain.auth.exception.AuthErrorCode;
 import org.mainapp.global.error.CustomException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 
-@Component
 public class SecurityUtil {
 	public static String getCurrentMemberId() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/application/main-app/src/main/java/org/mainapp/global/util/SecurityUtil.java
+++ b/application/main-app/src/main/java/org/mainapp/global/util/SecurityUtil.java
@@ -1,0 +1,19 @@
+package org.mainapp.global.util;
+
+import org.mainapp.domain.auth.exception.AuthErrorCode;
+import org.mainapp.global.error.CustomException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SecurityUtil {
+	public static String getCurrentMemberId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		try {
+			return authentication.getName();
+		} catch (Exception e) {
+			throw new CustomException(AuthErrorCode.AUTH_NOT_FOUND);
+		}
+	}
+}

--- a/application/main-app/src/main/resources/application-oauth.yml
+++ b/application/main-app/src/main/resources/application-oauth.yml
@@ -24,5 +24,5 @@ spring:
 jwt:
   access-token-key: ${ACCESS_JWT_KEY:}
   refresh-token-key: ${REFRESH_JWT_KEY:}
-  access-token-expiration: ${ACCESS_JWT_EXPIRATION:1800000}  # 30분
-  refresh-token-expiration: ${REFRESH_JWT_EXPIRATION:604800000} # 7일
+  access-token-expiration-ms: ${ACCESS_JWT_EXPIRATION:1800000}  # 30분
+  refresh-token-expiration-ms: ${REFRESH_JWT_EXPIRATION:604800000} # 7일


### PR DESCRIPTION
## 🌱 관련 이슈
- close #155 

## 📌 작업 내용 및 특이사항
- SecurityContextHoler에서 UserId값 가져오는 메서드 구현
- JwtProperteis값 못가져오는 에러 수정

### SecurityUtil.java
```java
public class SecurityUtil {
	public static String getCurrentMemberId() {
		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
		try {
			return authentication.getName();
		} catch (Exception e) {
			throw new CustomException(AuthErrorCode.AUTH_NOT_FOUND);
		}
	}
}
```

### 사용 방법
```java

	public List<PromptHistoriesResponse> getPromptHistories(Long agentId, Long postGroupId, Long postId) {
		final long userId = Long.parseLong(SecurityUtil.getCurrentMemberId());  // 이런식으로 userId를 가져올 수 있음

		List<PromptHistory> histories = promptHistoryRepository.findPromptHistoriesWithValidation(userId, agentId,
			postGroupId, postId);

		return PromptHistoriesResponse.fromList(histories);
	}
```
## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


