### PR TITLE
[#159] Feature: 계정 목록 조회 API 구현

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -7,15 +7,19 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/agents")
 @RequiredArgsConstructor
+@Tag(name = "Agent API", description = "사용자가 연동한 SNS 계정(에이전트)에 대한 요청을 처리하는 API입니다.")
 public class AgentController {
 
 	private final AgentService agentService;
 
+	@Operation(summary = "계정 목록 조회 API", description = "사용자가 연동한 SNS 계정 목록을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<GetAgentsResponse> getAgents() {
 		return ResponseEntity.ok(agentService.getAgents());

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -1,0 +1,20 @@
+package org.mainapp.domain.agent.controller;
+
+import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/agents")
+@RequiredArgsConstructor
+public class AgentController {
+
+	@GetMapping
+	public ResponseEntity<GetAgentsResponse> getAgents() {
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -1,6 +1,7 @@
 package org.mainapp.domain.agent.controller;
 
 import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
+import org.mainapp.domain.agent.service.AgentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -13,8 +14,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AgentController {
 
+	private final AgentService agentService;
+
 	@GetMapping
 	public ResponseEntity<GetAgentsResponse> getAgents() {
-		return ResponseEntity.noContent().build();
+		return ResponseEntity.ok(agentService.getAgents());
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetAgentsResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetAgentsResponse.java
@@ -1,0 +1,18 @@
+package org.mainapp.domain.agent.controller.response;
+
+import java.util.List;
+
+import org.domainmodule.agent.entity.Agent;
+import org.mainapp.domain.agent.controller.response.type.AgentResponse;
+
+public record GetAgentsResponse(
+	List<AgentResponse> agents
+) {
+
+	public static GetAgentsResponse from(List<Agent> agents) {
+		List<AgentResponse> agentResponses = agents.stream()
+			.map(AgentResponse::from)
+			.toList();
+		return new GetAgentsResponse(agentResponses);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetAgentsResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetAgentsResponse.java
@@ -5,7 +5,11 @@ import java.util.List;
 import org.domainmodule.agent.entity.Agent;
 import org.mainapp.domain.agent.controller.response.type.AgentResponse;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계정 목록 조회 API 응답 본문")
 public record GetAgentsResponse(
+	@Schema(description = "사용자 SNS 계정 리스트")
 	List<AgentResponse> agents
 ) {
 

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
@@ -1,0 +1,32 @@
+package org.mainapp.domain.agent.controller.response.type;
+
+import java.time.LocalDateTime;
+
+import org.domainmodule.agent.entity.Agent;
+import org.domainmodule.agent.entity.type.AgentPlanType;
+import org.domainmodule.agent.entity.type.AgentPlatformType;
+
+public record AgentResponse(
+	LocalDateTime createdAt,
+	Long agentId,
+	AgentPlatformType platform,
+	String accountId,
+	String bio,
+	String profileImageUrl,
+	AgentPlanType agentPlan,
+	Boolean autoMode
+) {
+
+	public static AgentResponse from(Agent agent) {
+		return new AgentResponse(
+			agent.getCreatedAt(),
+			agent.getId(),
+			agent.getPlatform(),
+			agent.getAccountId(),
+			agent.getBio(),
+			agent.getProfileImage(),
+			agent.getAgentPlan(),
+			agent.getAutoMode()
+		);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
@@ -6,14 +6,25 @@ import org.domainmodule.agent.entity.Agent;
 import org.domainmodule.agent.entity.type.AgentPlanType;
 import org.domainmodule.agent.entity.type.AgentPlatformType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "SNS 계정 응답 객체")
 public record AgentResponse(
+	@Schema(description = "계정 최초 연동 일시", example = "2025-01-01T00:00:00.000Z")
 	LocalDateTime createdAt,
+	@Schema(description = "계정 id (instead 내)", example = "1")
 	Long agentId,
+	@Schema(description = "SNS 종류", example = "X")
 	AgentPlatformType platform,
+	@Schema(description = "SNS 계정 id (외부 SNS 내)", example = "1")
 	String accountId,
+	@Schema(description = "계정 한줄소개", example = "최신 AI 소식을 전해드려요!")
 	String bio,
+	@Schema(description = "계정 프로필 이미지", example = "https://~")
 	String profileImageUrl,
+	@Schema(description = "계정 요금제 (외부 SNS 내)", example = "FREE")
 	AgentPlanType agentPlan,
+	@Schema(description = "Auto 모드 여부", example = "false")
 	Boolean autoMode
 ) {
 

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -1,10 +1,14 @@
 package org.mainapp.domain.agent.service;
 
+import java.util.List;
+
 import org.domainmodule.agent.entity.Agent;
 import org.domainmodule.agent.entity.type.AgentPlatformType;
 import org.domainmodule.agent.repository.AgentRepository;
 import org.domainmodule.user.entity.User;
+import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
 import org.mainapp.domain.user.service.UserService;
+import org.mainapp.global.util.SecurityUtil;
 import org.snsclient.twitter.dto.response.TwitterUserInfoDto;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class AgentService {
+
 	private final AgentRepository agentRepository;
 	private final UserService userService;
 
@@ -22,7 +27,7 @@ public class AgentService {
 	 */
 	public Agent updateOrCreateAgent(TwitterUserInfoDto userInfo) {
 		//TODO 임시 설정한 부분 (이후 securityContext에서 userId가져오기)
-		long userId = 1L;
+		Long userId = SecurityUtil.getCurrentUserId();
 		User user = userService.findUserById(userId);
 
 		// Agent가 이미 존재하는지 확인
@@ -46,5 +51,19 @@ public class AgentService {
 	private Agent updatAgent(Agent agent, TwitterUserInfoDto userInfo) {
 		agent.updateInfo(userInfo.description(), userInfo.profileImageUrl(), userInfo.subscriptionType());
 		return agentRepository.save(agent);
+	}
+
+	/**
+	 * 사용자에 해당하는 계정 목록을 조회하는 메서드
+	 */
+	public GetAgentsResponse getAgents() {
+		// 사용자 인증 정보 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+
+		// 사용자 계정 목록 조회
+		List<Agent> agents = agentRepository.findAllByUserId(userId);
+
+		// 반환
+		return GetAgentsResponse.from(agents);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/PromptHistoriesResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/PromptHistoriesResponse.java
@@ -2,13 +2,13 @@ package org.mainapp.domain.post.controller.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.domainmodule.post.entity.PromptHistory;
 import org.domainmodule.post.entity.type.PostPromptType;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+// TODO: GetPostPromptHistoriesResponse로 변경하기
 @Schema(description = "게시물 프롬프트 내역 응답 객체")
 public record PromptHistoriesResponse(
 	@Schema(description = "게시물 프롬프트 내역 id", example = "1")

--- a/application/main-app/src/main/java/org/mainapp/domain/token/service/TokenServiceImpl.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/token/service/TokenServiceImpl.java
@@ -55,7 +55,8 @@ public class TokenServiceImpl implements TokenService {
 
 	private void createAndSaveRefreshToken(Long userId, String token) {
 		User user = userService.findUserById(userId);
-		RefreshToken refreshToken = RefreshToken.create(user, token, Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs()).toSeconds());
+		RefreshToken refreshToken = RefreshToken.create(user, token,
+			Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs()).toSeconds());
 		refreshTokenRepository.save(refreshToken);
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/domain/user/service/UserServiceImpl.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/user/service/UserServiceImpl.java
@@ -19,7 +19,8 @@ public class UserServiceImpl implements UserService {
 	@Override
 	@Transactional
 	public User createAndSaveUser(OAuth2UserInfo oAuth2Response) {
-		User user = User.createUser(oAuth2Response.getEmail(),oAuth2Response.getName(), oAuth2Response.getProfileImage());
+		User user = User.createUser(oAuth2Response.getEmail(), oAuth2Response.getName(),
+			oAuth2Response.getProfileImage());
 		return userRepository.save(user);
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 public final class WebSecurityURI {
 
 	public static final List<String> PUBLIC_URIS = List.of(
-		"/auth/login/oauth2/code/google",
+		"/login/oauth2/code/google",
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/swagger-resources/**",

--- a/application/main-app/src/main/java/org/mainapp/global/util/JwtUtil.java
+++ b/application/main-app/src/main/java/org/mainapp/global/util/JwtUtil.java
@@ -49,13 +49,13 @@ public class JwtUtil {
 	public String generateRefreshToken(String userId) {
 		final Date now = new Date();
 		return Jwts.builder()
-				.setHeaderParam("typ", "JWT")
-				.setSubject(userId)
-				.setIssuer(ISSUER)
-				.setIssuedAt(now)
-				.setExpiration(new Date(now.getTime() + jwtProperties.getRefreshTokenExpirationMs()))
-				.signWith(getRefreshTokenKey(), SignatureAlgorithm.HS256)
-				.compact();
+			.setHeaderParam("typ", "JWT")
+			.setSubject(userId)
+			.setIssuer(ISSUER)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + jwtProperties.getRefreshTokenExpirationMs()))
+			.signWith(getRefreshTokenKey(), SignatureAlgorithm.HS256)
+			.compact();
 	}
 
 	private Key getAccessTokenKey() {
@@ -67,7 +67,7 @@ public class JwtUtil {
 	}
 
 	public boolean isTokenValid(String token, boolean isAccessToken) {
-		try{
+		try {
 			return (!isTokenExpired(token, isAccessToken));
 		} catch (SecurityException | MalformedJwtException e) {
 			log.error("Invalid JWT Token", e);
@@ -97,7 +97,7 @@ public class JwtUtil {
 	}
 
 	private <T> T extractClaim(String token, boolean isAccessToken, Function<Claims, T> claimResolver) {
-		Claims claims =  extractAllAccessTokenClaims(token, isAccessToken);
+		Claims claims = extractAllAccessTokenClaims(token, isAccessToken);
 		return claimResolver.apply(claims);
 	}
 

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
@@ -49,12 +49,12 @@ public class Agent extends BaseTimeEntity {
 	@Column(length = 500)
 	private String profileImage;
 
-	@Column(nullable = false)
-	private Boolean autoMode;
-
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
 	private AgentType agentType;
+
+	@Column(nullable = false)
+	private Boolean autoMode;
 
 	@Column(nullable = false)
 	private Boolean isActivated;

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
@@ -1,7 +1,7 @@
 package org.domainmodule.agent.entity;
 
+import org.domainmodule.agent.entity.type.AgentPlanType;
 import org.domainmodule.agent.entity.type.AgentPlatformType;
-import org.domainmodule.agent.entity.type.AgentType;
 import org.domainmodule.common.entity.BaseTimeEntity;
 import org.domainmodule.snstoken.entity.SnsToken;
 import org.domainmodule.user.entity.User;
@@ -51,7 +51,7 @@ public class Agent extends BaseTimeEntity {
 
 	@Enumerated(EnumType.STRING)
 	@Column(nullable = false)
-	private AgentType agentType;
+	private AgentPlanType agentPlan;
 
 	@Column(nullable = false)
 	private Boolean autoMode;
@@ -69,7 +69,7 @@ public class Agent extends BaseTimeEntity {
 		String accountId,
 		String bio,
 		String profileImage,
-		AgentType agentType
+		AgentPlanType agentPlan
 	) {
 		this.user = user;
 		this.platform = agentPlatform;
@@ -77,7 +77,7 @@ public class Agent extends BaseTimeEntity {
 		this.bio = bio;
 		this.profileImage = profileImage;
 		this.autoMode = Boolean.FALSE;
-		this.agentType = agentType;
+		this.agentPlan = agentPlan;
 		this.isActivated = Boolean.TRUE;
 	}
 
@@ -95,7 +95,7 @@ public class Agent extends BaseTimeEntity {
 			.accountId(accountId)
 			.bio(bio)
 			.profileImage(profileImage)
-			.agentType(AgentType.fromSubscription(subscriptionType))
+			.agentPlan(AgentPlanType.fromSubscription(subscriptionType))
 			.build();
 	}
 
@@ -107,6 +107,6 @@ public class Agent extends BaseTimeEntity {
 	) {
 		this.bio = bio;
 		this.profileImage = profileImage;
-		this.agentType = AgentType.fromSubscription(agentType);
+		this.agentPlan = AgentPlanType.fromSubscription(agentType);
 	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentPlanType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentPlanType.java
@@ -1,9 +1,9 @@
 package org.domainmodule.agent.entity.type;
 
-public enum AgentType {
+public enum AgentPlanType {
 	FREE, BASIC, PREMIUM, PREMIUM_PLUS;
 
-	public static AgentType fromSubscription(String subscriptionType) {
+	public static AgentPlanType fromSubscription(String subscriptionType) {
 		if (subscriptionType == null) {
 			return FREE;
 		}

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentType.java
@@ -1,7 +1,8 @@
 package org.domainmodule.agent.entity.type;
 
 public enum AgentType {
-	FREE, BASIC, PREMIUM, PREMIUM_PLUS ;
+	FREE, BASIC, PREMIUM, PREMIUM_PLUS;
+
 	public static AgentType fromSubscription(String subscriptionType) {
 		if (subscriptionType == null) {
 			return FREE;

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/repository/AgentRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/repository/AgentRepository.java
@@ -1,11 +1,21 @@
 package org.domainmodule.agent.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.domainmodule.agent.entity.Agent;
 import org.domainmodule.agent.entity.type.AgentPlatformType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface AgentRepository extends JpaRepository<Agent, Long> {
+
 	Optional<Agent> findByAccountIdAndPlatform(String accountId, AgentPlatformType platform);
+
+	@Query("""
+			select a from Agent a
+			join fetch a.user
+			where a.user.id = :userId
+		""")
+	List<Agent> findAllByUserId(Long userId);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #159 

## 📌 작업 내용 및 특이사항

### 1. AgentController 생성
계정 관련 API를 관리할 AgentController를 생성했습니다.

### 2. 계정 목록 조회 API 구현
사용자가 서비스 내에서 연동한 SNS 계정 목록을 조회하는 API를 구현했습니다. 이때 요청 쿠키에 담겨 오는 access token에서 뽑아낸 userId를 사용해 계정을 조회하기 위해, AgentRepository에 쿼리를 추가했습니다.
```java
public interface AgentRepository extends JpaRepository<Agent, Long> {

	@Query("""
			select a from Agent a
			join fetch a.user
			where a.user.id = :userId
		""")
	List<Agent> findAllByUserId(Long userId);
}
```

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
- 현재는 SNS 플랫폼에 관계 없이 모든 연결된 계정을 리스트로 응답하고 있어요. 지금 당장은 연동할 수 있는 SNS가 twitter밖에 없어 문제가 되지 않지만, 이후 SNS가 추가된다면 SNS 종류에 따라 계정 리스트를 구분하여 응답해야 할지 고민이 됩니다..!


