### PR TITLE
[#161] Feature: 계정 상세 조회 API 구현

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -27,6 +27,7 @@ public class AgentController {
 		return ResponseEntity.ok(agentService.getAgents());
 	}
 
+	@Operation(summary = "계정 상세 조회 API", description = "사용자가 연동한 SNS 계정의 상세 정보를 조회합니다.")
 	@GetMapping("/{agentId}")
 	public ResponseEntity<GetDetailAgentResponse> getDetailAgent(@PathVariable Long agentId) {
 		return ResponseEntity.ok(agentService.getDetailAgent(agentId));

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -29,6 +29,6 @@ public class AgentController {
 
 	@GetMapping("/{agentId}")
 	public ResponseEntity<GetDetailAgentResponse> getDetailAgent(@PathVariable Long agentId) {
-		return ResponseEntity.noContent().build();
+		return ResponseEntity.ok(agentService.getDetailAgent(agentId));
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -1,9 +1,11 @@
 package org.mainapp.domain.agent.controller;
 
 import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
+import org.mainapp.domain.agent.controller.response.GetDetailAgentResponse;
 import org.mainapp.domain.agent.service.AgentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,5 +25,10 @@ public class AgentController {
 	@GetMapping
 	public ResponseEntity<GetAgentsResponse> getAgents() {
 		return ResponseEntity.ok(agentService.getAgents());
+	}
+
+	@GetMapping("/{agentId}")
+	public ResponseEntity<GetDetailAgentResponse> getDetailAgent(@PathVariable Long agentId) {
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetDetailAgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetDetailAgentResponse.java
@@ -1,0 +1,24 @@
+package org.mainapp.domain.agent.controller.response;
+
+import org.domainmodule.agent.entity.Agent;
+import org.domainmodule.agent.entity.AgentPersonalSetting;
+import org.mainapp.domain.agent.controller.response.type.AgentPersonalSettingResponse;
+import org.mainapp.domain.agent.controller.response.type.AgentResponse;
+
+public record GetDetailAgentResponse(
+	AgentResponse agent,
+	AgentPersonalSettingResponse agentPersonalSetting
+) {
+
+	public static GetDetailAgentResponse from(
+		Agent agent,
+		AgentPersonalSetting personalSetting
+	) {
+		AgentResponse agentResponse = AgentResponse.from(agent);
+		AgentPersonalSettingResponse agentPersonalSettingResponse = AgentPersonalSettingResponse.from(personalSetting);
+		return new GetDetailAgentResponse(
+			agentResponse,
+			agentPersonalSettingResponse
+		);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetDetailAgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/GetDetailAgentResponse.java
@@ -5,8 +5,13 @@ import org.domainmodule.agent.entity.AgentPersonalSetting;
 import org.mainapp.domain.agent.controller.response.type.AgentPersonalSettingResponse;
 import org.mainapp.domain.agent.controller.response.type.AgentResponse;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계정 상세 조회 API 응답 본문")
 public record GetDetailAgentResponse(
+	@Schema(description = "사용자 SNS 계정 정보")
 	AgentResponse agent,
+	@Schema(description = "계정 개인화 설정 정보")
 	AgentPersonalSettingResponse agentPersonalSetting
 ) {
 

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentPersonalSettingResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentPersonalSettingResponse.java
@@ -1,0 +1,8 @@
+package org.mainapp.domain.agent.controller.response.type;
+
+public record AgentPersonalSettingResponse(
+	String domain,
+	String introduction,
+
+) {
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentPersonalSettingResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentPersonalSettingResponse.java
@@ -3,10 +3,17 @@ package org.mainapp.domain.agent.controller.response.type;
 import org.domainmodule.agent.entity.AgentPersonalSetting;
 import org.domainmodule.agent.entity.type.AgentToneType;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "SNS 계정 개인화 설정 응답 객체")
 public record AgentPersonalSettingResponse(
+	@Schema(description = "계정 분야", example = "IT 기술")
 	String domain,
+	@Schema(description = "계정 소개", example = "최신 IT 기술 소식을 전달하는 계정")
 	String introduction,
+	@Schema(description = "계정 말투에 대한 Enum", example = "CUSTOM")
 	AgentToneType tone,
+	@Schema(description = "계정 말투가 CUSTOM인 경우 적용되는 사용자 설정 말투", example = "20대 중반의 차분한 여성같은 말투, 중간중간 이모지 사용")
 	String customTone
 ) {
 

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentPersonalSettingResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentPersonalSettingResponse.java
@@ -1,8 +1,21 @@
 package org.mainapp.domain.agent.controller.response.type;
 
+import org.domainmodule.agent.entity.AgentPersonalSetting;
+import org.domainmodule.agent.entity.type.AgentToneType;
+
 public record AgentPersonalSettingResponse(
 	String domain,
 	String introduction,
-
+	AgentToneType tone,
+	String customTone
 ) {
+
+	public static AgentPersonalSettingResponse from(AgentPersonalSetting agentPersonalSetting) {
+		return new AgentPersonalSettingResponse(
+			agentPersonalSetting.getDomain(),
+			agentPersonalSetting.getIntroduction(),
+			agentPersonalSetting.getTone(),
+			agentPersonalSetting.getCustomTone()
+		);
+	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
@@ -20,7 +20,7 @@ public record AgentResponse(
 	String accountId,
 	@Schema(description = "계정 한줄소개", example = "최신 AI 소식을 전해드려요!")
 	String bio,
-	@Schema(description = "계정 프로필 이미지", example = "https://~")
+	@Schema(description = "계정 프로필 이미지 URL", example = "https://~")
 	String profileImageUrl,
 	@Schema(description = "계정 요금제 (외부 SNS 내)", example = "FREE")
 	AgentPlanType agentPlan,

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
@@ -10,10 +10,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "SNS 계정 응답 객체")
 public record AgentResponse(
+	@Schema(description = "계정 id (instead 내)", example = "1")
+	Long id,
 	@Schema(description = "계정 최초 연동 일시", example = "2025-01-01T00:00:00.000Z")
 	LocalDateTime createdAt,
-	@Schema(description = "계정 id (instead 내)", example = "1")
-	Long agentId,
 	@Schema(description = "SNS 종류", example = "X")
 	AgentPlatformType platform,
 	@Schema(description = "SNS 계정 id (외부 SNS 내)", example = "1")
@@ -30,8 +30,8 @@ public record AgentResponse(
 
 	public static AgentResponse from(Agent agent) {
 		return new AgentResponse(
-			agent.getCreatedAt(),
 			agent.getId(),
+			agent.getCreatedAt(),
 			agent.getPlatform(),
 			agent.getAccountId(),
 			agent.getBio(),

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/exception/AgentErrorCode.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/exception/AgentErrorCode.java
@@ -10,7 +10,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AgentErrorCode implements ErrorCodeStatus {
 
-	AGENT_NOT_FOUND(HttpStatus.NOT_FOUND, "Agent를 찾을 수 없습니다.");
+	AGENT_NOT_FOUND(HttpStatus.NOT_FOUND, "계정을 찾을 수 없습니다.");
+
 	private final HttpStatus httpStatus;
 	private final String message;
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -3,11 +3,17 @@ package org.mainapp.domain.agent.service;
 import java.util.List;
 
 import org.domainmodule.agent.entity.Agent;
+import org.domainmodule.agent.entity.AgentPersonalSetting;
 import org.domainmodule.agent.entity.type.AgentPlatformType;
+import org.domainmodule.agent.entity.type.AgentToneType;
+import org.domainmodule.agent.repository.AgentPersonalSettingRepository;
 import org.domainmodule.agent.repository.AgentRepository;
 import org.domainmodule.user.entity.User;
 import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
+import org.mainapp.domain.agent.controller.response.GetDetailAgentResponse;
+import org.mainapp.domain.agent.exception.AgentErrorCode;
 import org.mainapp.domain.user.service.UserService;
+import org.mainapp.global.error.CustomException;
 import org.mainapp.global.util.SecurityUtil;
 import org.snsclient.twitter.dto.response.TwitterUserInfoDto;
 import org.springframework.stereotype.Service;
@@ -18,15 +24,17 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AgentService {
 
-	private final AgentRepository agentRepository;
+	private final AgentTransactionService agentTransactionService;
 	private final UserService userService;
+	private final AgentRepository agentRepository;
+	private final AgentPersonalSettingRepository agentPersonalSettingRepository;
 
 	/**
 	 * X API 로그인을 성공한 후 Agent와 SnsToken 생성 및 저장
 	 * @return 생성된 Agent 엔티티
 	 */
 	public Agent updateOrCreateAgent(TwitterUserInfoDto userInfo) {
-		//TODO 임시 설정한 부분 (이후 securityContext에서 userId가져오기)
+		// 사용자 인증 정보 조회
 		Long userId = SecurityUtil.getCurrentUserId();
 		User user = userService.findUserById(userId);
 
@@ -45,12 +53,14 @@ public class AgentService {
 			userInfo.profileImageUrl(),
 			userInfo.subscriptionType()
 		);
-		return agentRepository.save(newAgent);
+		AgentPersonalSetting newAgentPersonalSetting = AgentPersonalSetting.create(
+			newAgent, "", "", AgentToneType.LESS_FORMAL, "");
+		return agentTransactionService.saveAgentAndPersonalSetting(newAgent, newAgentPersonalSetting);
 	}
 
 	private Agent updatAgent(Agent agent, TwitterUserInfoDto userInfo) {
 		agent.updateInfo(userInfo.description(), userInfo.profileImageUrl(), userInfo.subscriptionType());
-		return agentRepository.save(agent);
+		return agentTransactionService.saveAgent(agent);
 	}
 
 	/**
@@ -65,5 +75,20 @@ public class AgentService {
 
 		// 반환
 		return GetAgentsResponse.from(agents);
+	}
+
+	/**
+	 * 개인화 설정 정보가 포함된 계정 상세 정보를 조회하는 메서드
+	 */
+	public GetDetailAgentResponse getDetailAgent(Long agentId) {
+		// 사용자 인증 정보 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+
+		// 사용자 계정 및 개인화 설정 조회
+		AgentPersonalSetting agentPersonalSetting = agentPersonalSettingRepository.findByUserIdAndAgentId(
+			userId, agentId).orElseThrow(() -> new CustomException(AgentErrorCode.AGENT_NOT_FOUND));
+
+		// 반환
+		return GetDetailAgentResponse.from(agentPersonalSetting.getAgent(), agentPersonalSetting);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentTransactionService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentTransactionService.java
@@ -1,0 +1,38 @@
+package org.mainapp.domain.agent.service;
+
+import org.domainmodule.agent.entity.Agent;
+import org.domainmodule.agent.entity.AgentPersonalSetting;
+import org.domainmodule.agent.repository.AgentPersonalSettingRepository;
+import org.domainmodule.agent.repository.AgentRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AgentTransactionService {
+
+	private final AgentRepository agentRepository;
+	private final AgentPersonalSettingRepository agentPersonalSettingRepository;
+
+	@Transactional
+	public Agent saveAgent(Agent agent) {
+		return agentRepository.save(agent);
+	}
+
+	@Transactional
+	public AgentPersonalSetting saveAgentPersonalSetting(AgentPersonalSetting agentPersonalSetting) {
+		return agentPersonalSettingRepository.save(agentPersonalSetting);
+	}
+
+	@Transactional
+	public Agent saveAgentAndPersonalSetting(
+		Agent agent,
+		AgentPersonalSetting agentPersonalSetting
+	) {
+		Agent savedAgent = agentRepository.save(agent);
+		agentPersonalSettingRepository.save(agentPersonalSetting);
+		return savedAgent;
+	}
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/AgentPersonalSetting.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/AgentPersonalSetting.java
@@ -10,7 +10,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,7 +27,8 @@ public class AgentPersonalSetting {
 	@Column(name = "personal_setting_id")
 	private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "agent_id")
 	private Agent agent;
 
 	@Column(length = 20)

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/AgentPersonalSetting.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/AgentPersonalSetting.java
@@ -1,0 +1,64 @@
+package org.domainmodule.agent.entity;
+
+import org.domainmodule.agent.entity.type.AgentToneType;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AgentPersonalSetting {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "personal_setting_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	private Agent agent;
+
+	@Column(length = 20)
+	private String domain;
+
+	@Column(length = 500)
+	private String introduction;
+
+	@Enumerated(EnumType.STRING)
+	private AgentToneType tone;
+
+	@Column(length = 50)
+	private String customTone;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private AgentPersonalSetting(
+		Agent agent, String domain, String introduction, AgentToneType tone, String customTone) {
+		this.agent = agent;
+		this.domain = domain;
+		this.introduction = introduction;
+		this.tone = tone;
+		this.customTone = customTone;
+	}
+
+	public static AgentPersonalSetting create(
+		Agent agent, String domain, String introduction, AgentToneType tone, String customTone) {
+		return AgentPersonalSetting.builder()
+			.agent(agent)
+			.domain(domain)
+			.introduction(introduction)
+			.tone(tone)
+			.customTone(customTone)
+			.build();
+	}
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentToneType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentToneType.java
@@ -1,0 +1,5 @@
+package org.domainmodule.agent.entity.type;
+
+public enum AgentToneType {
+	CASUAL, LESS_FORMAL, MORE_FORMAL, CUSTOM
+}

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/repository/AgentPersonalSettingRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/repository/AgentPersonalSettingRepository.java
@@ -1,0 +1,19 @@
+package org.domainmodule.agent.repository;
+
+import java.util.Optional;
+
+import org.domainmodule.agent.entity.AgentPersonalSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface AgentPersonalSettingRepository extends JpaRepository<AgentPersonalSetting, Long> {
+
+	@Query("""
+			select aps from AgentPersonalSetting aps
+			join fetch aps.agent
+			join fetch aps.agent.user
+			where aps.agent.id = :agentId
+			and aps.agent.user.id = :userId
+		""")
+	Optional<AgentPersonalSetting> findByUserIdAndAgentId(Long userId, Long agentId);
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #161 

## 📌 작업 내용 및 특이사항

### 1. AgentPersonalSetting 엔티티 & AgentPersonalSettingRepository 생성
추가된 테이블인 계정 개인화 설정 테이블에 매핑되는 엔티티인 AgentPersonalSetting 엔티티를 생성했습니다.
또한, repository에 userId와 agentId를 바탕으로 개인화 설정 엔티티까지 상세 조회하는 쿼리를 작성했습니다.

### 2. AgentTransactionService 구현
AgentService 내에서의 트랜잭션을 분리하기 위한 AgentTransactionService를 구현했습니다.

### 3. 계정 상세 조회 API 구현
홈 화면 사이드바에서 계정을 선택했을 때 화면에 뿌려줄 계정 정보를 제공하기 위한 계정 상세 조회 API를 구현했습니다.