### PR TITLE
[#163] Refactor: User 로그인 및 Agent 로그인 추가됨에 따라 기존 API에서의 검증 로직 변경

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -26,7 +26,6 @@ public class AgentService {
 	 * @return 생성된 Agent 엔티티
 	 */
 	public Agent updateOrCreateAgent(TwitterUserInfoDto userInfo) {
-		//TODO 임시 설정한 부분 (이후 securityContext에서 userId가져오기)
 		Long userId = SecurityUtil.getCurrentUserId();
 		User user = userService.findUserById(userId);
 

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -60,7 +60,7 @@ public class PostController {
 		@RequestParam(defaultValue = PostGenerationCount.POST_GENERATION_POST_COUNT) Integer limit,
 		@Validated @RequestBody CreatePostsRequest createPostsRequest
 	) {
-		return ResponseEntity.ok(postService.createPosts(createPostsRequest, limit));
+		return ResponseEntity.ok(postService.createPosts(agentId, createPostsRequest, limit));
 	}
 
 	@Operation(

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -87,7 +87,7 @@ public class PostController {
 		@PathVariable Long agentId,
 		@PathVariable Long postGroupId
 	) {
-		return ResponseEntity.ok(postService.getPostsByPostGroup(postGroupId));
+		return ResponseEntity.ok(postService.getPostsByPostGroup(agentId, postGroupId));
 	}
 
 	@Operation(summary = "게시물 프롬프트 내역 조회 API", description = "게시물 결과 수정 단계에서 프롬프트 내역을 조회합니다.")

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -122,7 +122,7 @@ public class PostController {
 		@PathVariable Long postId,
 		@Validated @RequestBody UpdatePostContentRequest updatePostContentRequest
 	) {
-		postService.updatePostContent(postGroupId, postId, updatePostContentRequest);
+		postService.updatePostContent(agentId, postGroupId, postId, updatePostContentRequest);
 		return ResponseEntity.ok().build();
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -181,7 +181,7 @@ public class PostController {
 		@PathVariable Long postGroupId,
 		@PathVariable Long postId
 	) {
-		postService.deletePost(postGroupId, postId);
+		postService.deletePost(agentId, postGroupId, postId);
 		return ResponseEntity.noContent().build();
 	}
 
@@ -200,7 +200,7 @@ public class PostController {
 		@PathVariable Long postGroupId,
 		@Validated @RequestBody List<Long> postIds
 	) {
-		postService.deletePosts(postGroupId, postIds);
+		postService.deletePosts(agentId, postGroupId, postIds);
 		return ResponseEntity.noContent().build();
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -139,7 +139,7 @@ public class PostController {
 		@PathVariable Long postGroupId,
 		@Validated @RequestBody UpdatePostsMetadataRequest updatePostsMetadataRequest
 	) {
-		postService.updatePostsMetadata(postGroupId, updatePostsMetadataRequest);
+		postService.updatePostsMetadata(agentId, postGroupId, updatePostsMetadataRequest);
 		return ResponseEntity.ok().build();
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -78,7 +78,7 @@ public class PostController {
 		@PathVariable Long postGroupId,
 		@RequestParam(defaultValue = PostGenerationCount.POST_GENERATION_POST_COUNT) Integer limit
 	) {
-		return ResponseEntity.ok(postService.createAdditionalPosts(postGroupId, limit));
+		return ResponseEntity.ok(postService.createAdditionalPosts(agentId, postGroupId, limit));
 	}
 
 	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostCreateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostCreateService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.domainmodule.agent.entity.Agent;
 import org.domainmodule.post.entity.Post;
 import org.domainmodule.post.entity.type.PostStatusType;
 import org.domainmodule.post.repository.PostRepository;
@@ -64,12 +65,12 @@ public class PostCreateService {
 	/**
 	 * 참고자료 없는 게시물 그룹과 게시물 생성 및 저장 메서드
 	 */
-	public CreatePostsResponse createPostsWithoutRef(CreatePostsRequest request, Integer limit) {
+	public CreatePostsResponse createPostsWithoutRef(Agent agent, CreatePostsRequest request, Integer limit) {
 		// 게시물 생성
 		ChatCompletionResponse result = generatePostsWithoutRef(GeneratePostsVo.of(request, limit));
 
-		// PostGroup 엔티티 생성
-		PostGroup postGroup = PostGroup.createPostGroup(null, null, request.getTopic(), request.getPurpose(),
+		// PostGroup 엔티티 생성: 생성 횟수 1로 초기화
+		PostGroup postGroup = PostGroup.createPostGroup(agent, null, request.getTopic(), request.getPurpose(),
 			request.getReference(), request.getLength(), request.getContent(), 1);
 
 		// Post 엔티티 생성: OpenAI API 응답의 choices에서 답변 꺼내 json으로 파싱 후 엔티티 생성
@@ -95,7 +96,7 @@ public class PostCreateService {
 	/**
 	 * 뉴스 기사 기반 게시물 그룹과 게시물 생성 및 저장 메서드
 	 */
-	public CreatePostsResponse createPostsByNews(CreatePostsRequest request, Integer limit) {
+	public CreatePostsResponse createPostsByNews(Agent agent, CreatePostsRequest request, Integer limit) {
 		// newsCategory 필드 검증
 		if (request.getNewsCategory() == null) {
 			throw new CustomException(PostErrorCode.NO_NEWS_CATEGORY);
@@ -111,7 +112,7 @@ public class PostCreateService {
 			GeneratePostsVo.of(request, limit), feedPagingResult);
 
 		// PostGroup 엔티티 생성
-		PostGroup postGroup = PostGroup.createPostGroup(null, rssFeed, request.getTopic(), request.getPurpose(),
+		PostGroup postGroup = PostGroup.createPostGroup(agent, rssFeed, request.getTopic(), request.getPurpose(),
 			request.getReference(), request.getLength(), request.getContent(), 1);
 
 		// PostGroupRssCursor 엔티티 생성
@@ -143,7 +144,7 @@ public class PostCreateService {
 	/**
 	 * 이미지 기반 게시물 그룹과 게시물 생성 및 저장 메서드
 	 */
-	public CreatePostsResponse createPostsByImage(CreatePostsRequest request, Integer limit) {
+	public CreatePostsResponse createPostsByImage(Agent agent, CreatePostsRequest request, Integer limit) {
 		// imageUrls 필드 검증
 		if (request.getImageUrls() == null) {
 			throw new CustomException(PostErrorCode.NO_IMAGE_URLS);
@@ -153,7 +154,7 @@ public class PostCreateService {
 		ChatCompletionResponse result = generatePostsByImage(GeneratePostsVo.of(request, limit));
 
 		// PostGroup 엔티티 생성
-		PostGroup postGroup = PostGroup.createPostGroup(null, null, request.getTopic(), request.getPurpose(),
+		PostGroup postGroup = PostGroup.createPostGroup(agent, null, request.getTopic(), request.getPurpose(),
 			request.getReference(), request.getLength(), request.getContent(), 1);
 
 		// PostGroupImage 엔티티 리스트 생성

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -86,9 +86,10 @@ public class PostService {
 	 * postGroupId를 바탕으로 게시물 그룹 존재 여부를 확인하고, 해당 그룹의 게시물 목록을 반환하는 메서드
 	 * 게시물 그룹 조회 실패 시 POST_GROUP_NOT_FOUND
 	 */
-	public GetPostGroupPostsResponse getPostsByPostGroup(Long postGroupId) {
-		// PostGroup 엔티티 조회
-		PostGroup postGroup = postGroupRepository.findById(postGroupId)
+	public GetPostGroupPostsResponse getPostsByPostGroup(Long agentId, Long postGroupId) {
+		// 사용자 인증 정보 및 PostGroup 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
 		// Post 엔티티 리스트 조회

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -58,9 +58,10 @@ public class PostService {
 	 * 게시물 추가 생성 메서드.
 	 * postGroupId를 바탕으로 DB에서 PostGroup을 조회한 뒤, referenceType에 맞는 메서드 호출
 	 */
-	public CreatePostsResponse createAdditionalPosts(Long postGroupId, Integer limit) {
-		// PostGroup 조회
-		PostGroup postGroup = postGroupRepository.findById(postGroupId)
+	public CreatePostsResponse createAdditionalPosts(Long agentId, Long postGroupId, Integer limit) {
+		// 사용자 인증 정보 및 PostGroup 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
 		// PostGroup의 게시물 생성 횟수 검증

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -93,7 +93,7 @@ public class PostService {
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
 		// Post 엔티티 리스트 조회
-		List<Post> posts = postRepository.findAllByPostGroup(postGroup);
+		List<Post> posts = postRepository.findAllWithImagesByPostGroup(postGroup);
 
 		// 결과 반환
 		return GetPostGroupPostsResponse.of(postGroup, posts);
@@ -118,8 +118,18 @@ public class PostService {
 	/**
 	 * 게시물 내용 수정 메서드.
 	 */
-	public void updatePostContent(Long postGroupId, Long postId, UpdatePostContentRequest request) {
-		postUpdateService.updatePostContent(postGroupId, postId, request);
+	public void updatePostContent(Long agentId, Long postGroupId, Long postId, UpdatePostContentRequest request) {
+		// 사용자 인증 정보 및 PostGroup 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
+
+		// Post 조회
+		// Post post = postRepository.findByPostGroupAndId(postGroup, postId)
+		Post post = postRepository.findWithImagesByPostGroupAndId(postGroup, postId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+
+		postUpdateService.updatePostContent(post, request);
 	}
 
 	/**

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostTransactionService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostTransactionService.java
@@ -122,6 +122,7 @@ public class PostTransactionService {
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
 	}
 
+	// TODO: 하위 서비스인 PostTransactionService에서 상위 서비스인 PostPromptHistoryService 주입받고 있음.
 	@Transactional
 	public PostResponse updateSinglePostAndPromptyHistory(Post post, String prompt, SummaryContentFormat newContent) {
 		// 프롬프트 기록 저장

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostTransactionService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostTransactionService.java
@@ -117,8 +117,8 @@ public class PostTransactionService {
 	}
 
 	@Transactional(readOnly = true)
-	public Post getPostOrThrow(Long postId) {
-		return postRepository.findById(postId)
+	public Post getPostOrThrow(PostGroup postGroup, Long postId) {
+		return postRepository.findByPostGroupAndId(postGroup, postId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostUpdateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostUpdateService.java
@@ -7,11 +7,9 @@ import org.domainmodule.post.entity.PostImage;
 import org.domainmodule.post.entity.type.PostStatusType;
 import org.domainmodule.post.repository.PostImageRepository;
 import org.domainmodule.post.repository.PostRepository;
-import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.repository.PostGroupRepository;
 import org.mainapp.domain.post.controller.request.UpdatePostContentRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
-import org.mainapp.domain.post.controller.request.type.UpdatePostsRequestItem;
 import org.mainapp.domain.post.exception.PostErrorCode;
 import org.mainapp.global.error.CustomException;
 import org.springframework.stereotype.Service;
@@ -76,24 +74,7 @@ public class PostUpdateService {
 	/**
 	 * 게시물 기타 정보 수정 메서드.
 	 */
-	public void updatePostsMetadata(Long postGroupId, UpdatePostsMetadataRequest request) {
-		// PostGroup 엔티티 조회
-		PostGroup postGroup = postGroupRepository.findById(postGroupId)
-			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
-
-		// Post 엔티티 리스트 조회
-		List<Long> postIds = request.getPosts().stream()
-			.map(UpdatePostsRequestItem::getPostId)
-			.toList();
-		List<Post> posts = postRepository.findAllById(postIds);
-
-		// 검증: PostGroup에 해당하는 Post가 맞는지 검증
-		posts.forEach(post -> {
-			if (!post.getPostGroup().getId().equals(postGroupId)) {
-				throw new CustomException(PostErrorCode.INVALID_POST);
-			}
-		});
-
+	public void updatePostsMetadata(List<Post> posts, UpdatePostsMetadataRequest request) {
 		// Post 엔티티 리스트 수정
 		request.getPosts()
 			.forEach(postRequest -> {

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostUpdateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostUpdateService.java
@@ -31,20 +31,7 @@ public class PostUpdateService {
 	/**
 	 * 게시물 내용 수정 메서드. updateType에 따라 분기
 	 */
-	public void updatePostContent(Long postGroupId, Long postId, UpdatePostContentRequest request) {
-		// PostGroup 엔티티 조회
-		PostGroup postGroup = postGroupRepository.findById(postGroupId)
-			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
-
-		// Post 엔티티 조회
-		Post post = postRepository.findById(postId)
-			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
-
-		// 검증: PostGroup에 해당하는 Post가 맞는지 검증
-		if (!post.getPostGroup().getId().equals(postGroupId)) {
-			throw new CustomException(PostErrorCode.INVALID_POST);
-		}
-
+	public void updatePostContent(Post post, UpdatePostContentRequest request) {
 		// content 필드 검증 및 Post 엔티티 수정
 		if (request.getContent() == null) {
 			throw new CustomException(PostErrorCode.INVALID_UPDATING_POST_TYPE);
@@ -67,9 +54,8 @@ public class PostUpdateService {
 			throw new CustomException(PostErrorCode.INVALID_UPDATING_POST_TYPE);
 		}
 
-		// PostImage 엔티티 조회
-		List<PostImage> postImages = postImageRepository.findAllByPost(post);
-		List<String> savedImageUrls = postImages.stream()
+		// Post 엔티티 내 PostImage 엔티티 리스트 조회
+		List<String> savedImageUrls = post.getPostImages().stream()
 			.map(PostImage::getUrl)
 			.toList();
 
@@ -81,7 +67,7 @@ public class PostUpdateService {
 		postTransactionService.savePostImages(newPostImages);
 
 		// DB에만 존재하는 PostImage 엔티티 제거
-		List<PostImage> removedPostImages = postImages.stream()
+		List<PostImage> removedPostImages = post.getPostImages().stream()
 			.filter(postImage -> !request.getImageUrls().contains(postImage.getUrl()))
 			.toList();
 		postTransactionService.deletePostImages(removedPostImages);

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/vo/GeneratePostsVo.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/vo/GeneratePostsVo.java
@@ -35,7 +35,22 @@ public record GeneratePostsVo(
 		// PostGroup의 feed가 null인 경우 처리
 		FeedCategoryType newsCategory = (postGroup.getFeed() == null) ? null : postGroup.getFeed().getCategory();
 
-		List<String> imageUrls = postGroup.getPostGroupImages().stream()
+		return new GeneratePostsVo(
+			postGroup.getTopic(),
+			postGroup.getPurpose(),
+			postGroup.getLength(),
+			postGroup.getContent(),
+			newsCategory,
+			null,
+			limit
+		);
+	}
+
+	public static GeneratePostsVo of(PostGroup postGroup, List<PostGroupImage> images, Integer limit) {
+		// PostGroup의 feed가 null인 경우 처리
+		FeedCategoryType newsCategory = (postGroup.getFeed() == null) ? null : postGroup.getFeed().getCategory();
+
+		List<String> imageUrls = images.stream()
 			.map(PostGroupImage::getUrl)
 			.toList();
 

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
@@ -59,6 +59,7 @@ public class Agent extends BaseTimeEntity {
 	@Column(nullable = false)
 	private Boolean isActivated;
 
+	// TODO: OneToOne 관계에서 mappedBy 필드는 지연 로딩 설정해놔도 즉시 로딩으로 동작한다고 함, 여기서 추가 쿼리 계속 발생.
 	@OneToOne(mappedBy = "agent", fetch = FetchType.LAZY)
 	private SnsToken snsToken;
 

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/repository/AgentRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/repository/AgentRepository.java
@@ -18,4 +18,12 @@ public interface AgentRepository extends JpaRepository<Agent, Long> {
 			where a.user.id = :userId
 		""")
 	List<Agent> findAllByUserId(Long userId);
+
+	@Query("""
+			select a from Agent a
+			join fetch a.user
+			where a.user.id = :userId
+			and a.id = :agentId
+		""")
+	Optional<Agent> findByUserIdAndId(Long userId, Long agentId);
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -25,6 +25,14 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findPostsWithSnsTokenByTimeRange(LocalDateTime startTime, LocalDateTime endTime,
 		@Param("status") PostStatusType status);
 
+	// PostGroup과 postIds에 해당하는 Post 리스트를 조회
+	@Query("""
+			select p from Post p
+			where p.postGroup = :postGroup
+			and p.id in :postIds
+		""")
+	List<Post> findAllByPostGroupAndId(PostGroup postGroup, List<Long> postIds);
+
 	// PostGroup에 해당하는 Post 리스트를 이미지까지 함께 조회
 	@Query("""
 			select distinct p from Post p

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -25,13 +25,30 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	List<Post> findPostsWithSnsTokenByTimeRange(LocalDateTime startTime, LocalDateTime endTime,
 		@Param("status") PostStatusType status);
 
-	// PostGroup에 해당하는 Post 리스트 조회
+	// PostGroup에 해당하는 Post 리스트를 이미지까지 함께 조회
 	@Query("""
 			select distinct p from Post p
-			left join fetch p.postImages pi
+			left join fetch p.postImages
 			where p.postGroup = :postGroup
 		""")
-	List<Post> findAllByPostGroup(PostGroup postGroup);
+	List<Post> findAllWithImagesByPostGroup(PostGroup postGroup);
+
+	// PostGroup과 postId에 해당하는 Post를 조회
+	@Query("""
+			select distinct p from Post p
+			where p.postGroup = :postGroup
+			and p.id = :postId
+		""")
+	Optional<Post> findByPostGroupAndId(PostGroup postGroup, Long postId);
+
+	// PostGroup과 postId에 해당하는 Post를 이미지까지 함께 조회
+	@Query("""
+			select distinct p from Post p
+			left join fetch p.postImages
+			where p.postGroup = :postGroup
+			and p.id = :postId
+		""")
+	Optional<Post> findWithImagesByPostGroupAndId(PostGroup postGroup, Long postId);
 
 	// PostGroup에 해당하는 Post 중에서, 상태가 GENERATED인 게시물 중 order가 가장 큰 Post 조회
 	@Query("""

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -27,7 +27,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	// PostGroup에 해당하는 Post 리스트 조회
 	@Query("""
-			select p from Post p
+			select distinct p from Post p
 			left join fetch p.postImages pi
 			where p.postGroup = :postGroup
 		""")

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -43,7 +43,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
 	// PostGroup과 postId에 해당하는 Post를 조회
 	@Query("""
-			select distinct p from Post p
+			select p from Post p
 			where p.postGroup = :postGroup
 			and p.id = :postId
 		""")

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupImageRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupImageRepository.java
@@ -1,7 +1,12 @@
 package org.domainmodule.postgroup.repository;
 
+import java.util.List;
+
+import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostGroupImageRepository extends JpaRepository<PostGroupImage, Long> {
+
+	List<PostGroupImage> findAllByPostGroup(PostGroup postGroup);
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
@@ -1,7 +1,20 @@
 package org.domainmodule.postgroup.repository;
 
+import java.util.Optional;
+
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PostGroupRepository extends JpaRepository<PostGroup, Long> {
+
+	@Query("""
+			select pg from PostGroup pg
+			join fetch pg.agent
+			join fetch pg.agent.user
+			where pg.agent.user.id = :userId
+			and pg.agent.id = :agentId
+			and pg.id = :postGroupId
+		""")
+	Optional<PostGroup> findByUserIdAndAgentIdAndId(Long userId, Long agentId, Long postGroupId);
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/snstoken/entity/SnsToken.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/snstoken/entity/SnsToken.java
@@ -22,6 +22,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SnsToken extends BaseAuditEntity {
+	// TODO: SnsToken과 RefreshToken이 항상 헷갈려서, 연관된 테이블을 명시하는 쪽으로 네이밍 변경하면 어떨지 (UserToken, AgentToken 이런 식으로)
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "sns_token_id")


### PR DESCRIPTION
## 🌱 관련 이슈
- close #163 

## 📌 작업 내용 및 특이사항

### PostGroup 및 Post 조회 방식 변경
User 및 Agent 로그인이 활성화되었습니다. 따라서 기존에 PostGroup과 Post로만 조회를 수행했던 로직을, User와 Agent까지 포함해서 DB에서 조회하도록 변경했습니다. (유효한 User-Agent-PostGroup 내의 Post인지 검증하기 위해)

또한, Post와 PostGroup을 조회하는 부분을, post 도메인의 최상위 Service인 PostService에서 수행하도록 통일했어요. 거의 모든 메서드에서 다음 3줄짜리 코드가 사용되고 있어서, 별도 메서드로 분리하는 방법도 고려해볼만 한 것 같아요.
```java
Long userId = SecurityUtil.getCurrentUserId();
PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
    .orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
```

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
- PostPromptHistoryService를 PostTransactionService가 주입받고 있는 구조를 확인했어요. 제가 생각한 바람직한 post 도메인의 Service 의존관계는 다음과 같은데, 어떻게 생각하시나요?
```
PostService -> Post{Create,Update,PromptHistory,PromptUpdate}Service -> PostTransactionService
```
- Agent - SnsToken이 OneToOne 관계로 매핑되어 있는데, OneToOne 관계에서는 mappedBy로 설정된 필드에서 지연 로딩을 설정해도 즉시 로딩이 반영된다고 하더라구요. 그래서 SnsToken이 필요 없는 쿼리에서도 불필요하게 추가 쿼리가 발생하는 문제가 있었습니다. 이 부분을 어떻게 해결할지 생각해보면 좋을 것 같아요 (Agent에서 mappedBy 필드를 제거하거나, 만약 해당 필드가 필요하다면 fetch join을 사용하는 쪽으로)
- 사소한 부분인데, SnsToken과 RefreshToken이 계속 헷갈려요..ㅎㅎ 어떤 테이블에 연관된 토큰인지 명시하도록 네이밍 변경을 고려해보면 어떨까요? 예를 들어 RefreshToken -> UserToken, SnsToken -> AgentToken 이런 식으로요!