### PR TITLE
[#172] Feature: 계정 개인화 설정 수정 API 구현

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -5,6 +5,7 @@ import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
 import org.mainapp.domain.agent.controller.response.GetDetailAgentResponse;
 import org.mainapp.domain.agent.service.AgentService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -46,7 +47,7 @@ public class AgentController {
 	@PutMapping("/{agentId}/personal-setting")
 	public ResponseEntity<Void> updateAgentPersonalSetting(
 		@PathVariable Long agentId,
-		@RequestBody UpdateAgentPersonalSettingRequest request
+		@Validated @RequestBody UpdateAgentPersonalSettingRequest request
 	) {
 		agentService.updateAgentPersonalSetting(agentId, request);
 		return ResponseEntity.ok().build();

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -42,7 +42,9 @@ public class AgentController {
 		description = """
 			사용자가 연동한 SNS 계정의 개인화 설정을 변경합니다.
 
-			**변경되는 필드만 채워주시면 됩니다!**"""
+			**변경되는 필드만 채워주시면 됩니다!**
+
+			빈 문자열로는 변경할 수 없습니다."""
 	)
 	@PutMapping("/{agentId}/personal-setting")
 	public ResponseEntity<Void> updateAgentPersonalSetting(

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -1,11 +1,14 @@
 package org.mainapp.domain.agent.controller;
 
+import org.mainapp.domain.agent.controller.request.UpdateAgentPersonalSettingRequest;
 import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
 import org.mainapp.domain.agent.controller.response.GetDetailAgentResponse;
 import org.mainapp.domain.agent.service.AgentService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +34,20 @@ public class AgentController {
 	@GetMapping("/{agentId}")
 	public ResponseEntity<GetDetailAgentResponse> getDetailAgent(@PathVariable Long agentId) {
 		return ResponseEntity.ok(agentService.getDetailAgent(agentId));
+	}
+
+	@Operation(
+		summary = "계정 개인화 설정 수정 API",
+		description = """
+			사용자가 연동한 SNS 계정의 개인화 설정을 변경합니다.
+
+			**변경되는 필드만 채워주시면 됩니다!**"""
+	)
+	@PutMapping("/{agentId}/personal-setting")
+	public ResponseEntity<Void> updateAgentPersonalSetting(
+		@PathVariable Long agentId,
+		@RequestBody UpdateAgentPersonalSettingRequest request
+	) {
+		return ResponseEntity.ok().build();
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/AgentController.java
@@ -48,6 +48,7 @@ public class AgentController {
 		@PathVariable Long agentId,
 		@RequestBody UpdateAgentPersonalSettingRequest request
 	) {
+		agentService.updateAgentPersonalSetting(agentId, request);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/request/UpdateAgentPersonalSettingRequest.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/request/UpdateAgentPersonalSettingRequest.java
@@ -2,18 +2,28 @@ package org.mainapp.domain.agent.controller.request;
 
 import org.domainmodule.agent.entity.AgentPersonalSetting;
 import org.domainmodule.agent.entity.type.AgentToneType;
+import org.springframework.lang.Nullable;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "계정 개인화 설정 수정 API 요청 본문")
 public record UpdateAgentPersonalSettingRequest(
 	@Schema(description = "계정 분야", example = "IT 기술")
+	@Size(max = 20, message = "계정 분야는 20자 이내로 작성해주세요.")
+	@NotBlank(message = "계정 분야는 빈 문자열로 설정할 수 없습니다.")
 	String domain,
 	@Schema(description = "계정 소개", example = "최신 IT 기술 소식을 전달하는 계정")
+	@Size(max = 500, message = "계정 소개는 500자 이내로 작성해주세요.")
+	@NotBlank(message = "계정 소개는 빈 문자열로 설정할 수 없습니다.")
 	String introduction,
 	@Schema(description = "계정 말투에 대한 Enum", example = "CUSTOM")
+	@Nullable
 	AgentToneType tone,
 	@Schema(description = "계정 말투가 CUSTOM인 경우 적용되는 사용자 설정 말투", example = "20대 중반의 차분한 여성같은 말투, 중간중간 이모지 사용")
+	@Size(max = 50, message = "사용자 지정 말투는 50자 이내로 작성해주세요.")
+	@NotBlank(message = "사용자 지정 말투는 빈 문자열로 설정할 수 없습니다.")
 	String customTone
 ) {
 

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/request/UpdateAgentPersonalSettingRequest.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/request/UpdateAgentPersonalSettingRequest.java
@@ -1,0 +1,28 @@
+package org.mainapp.domain.agent.controller.request;
+
+import org.domainmodule.agent.entity.AgentPersonalSetting;
+import org.domainmodule.agent.entity.type.AgentToneType;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계정 개인화 설정 수정 API 요청 본문")
+public record UpdateAgentPersonalSettingRequest(
+	@Schema(description = "계정 분야", example = "IT 기술")
+	String domain,
+	@Schema(description = "계정 소개", example = "최신 IT 기술 소식을 전달하는 계정")
+	String introduction,
+	@Schema(description = "계정 말투에 대한 Enum", example = "CUSTOM")
+	AgentToneType tone,
+	@Schema(description = "계정 말투가 CUSTOM인 경우 적용되는 사용자 설정 말투", example = "20대 중반의 차분한 여성같은 말투, 중간중간 이모지 사용")
+	String customTone
+) {
+
+	public static UpdateAgentPersonalSettingRequest from(AgentPersonalSetting agentPersonalSetting) {
+		return new UpdateAgentPersonalSettingRequest(
+			agentPersonalSetting.getDomain(),
+			agentPersonalSetting.getIntroduction(),
+			agentPersonalSetting.getTone(),
+			agentPersonalSetting.getCustomTone()
+		);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -9,6 +9,7 @@ import org.domainmodule.agent.entity.type.AgentToneType;
 import org.domainmodule.agent.repository.AgentPersonalSettingRepository;
 import org.domainmodule.agent.repository.AgentRepository;
 import org.domainmodule.user.entity.User;
+import org.mainapp.domain.agent.controller.request.UpdateAgentPersonalSettingRequest;
 import org.mainapp.domain.agent.controller.response.GetAgentsResponse;
 import org.mainapp.domain.agent.controller.response.GetDetailAgentResponse;
 import org.mainapp.domain.agent.exception.AgentErrorCode;
@@ -90,5 +91,34 @@ public class AgentService {
 
 		// 반환
 		return GetDetailAgentResponse.from(agentPersonalSetting.getAgent(), agentPersonalSetting);
+	}
+
+	/**
+	 * 계정의 개인화 설정을 변경하는 메서드
+	 */
+	public void updateAgentPersonalSetting(Long agentId, UpdateAgentPersonalSettingRequest request) {
+		// 사용자 인증 정보 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+
+		// 사용자 계정 및 개인화 설정 조회
+		AgentPersonalSetting agentPersonalSetting = agentPersonalSettingRepository.findByUserIdAndAgentId(
+			userId, agentId).orElseThrow(() -> new CustomException(AgentErrorCode.AGENT_NOT_FOUND));
+
+		// 개인화 설정 수정
+		if (request.domain() != null) {
+			agentPersonalSetting.updateDomain(request.domain());
+		}
+		if (request.introduction() != null) {
+			agentPersonalSetting.updateIntroduction(request.introduction());
+		}
+		if (request.tone() != null) {
+			agentPersonalSetting.updateTone(request.tone());
+		}
+		if (request.customTone() != null) {
+			agentPersonalSetting.updateCustomTone(request.customTone());
+		}
+
+		// 변경사항 저장
+		agentTransactionService.saveAgentPersonalSetting(agentPersonalSetting);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/MultiplePostUpdateRequest.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/MultiplePostUpdateRequest.java
@@ -3,12 +3,15 @@ package org.mainapp.domain.post.controller.request;
 import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시물 프롬프트 기반 일괄 수정 API 요청 본문")
 public record MultiplePostUpdateRequest(
 	@Schema(description = "일괄 수정에 사용할 프롬프트", example = "말투를 부드럽게 전부 수정해줘")
+	@NotNull(message = "수정에 사용할 프롬프트를 입력해주세요.")
 	String prompt,
 	@Schema(description = "일괄 수정 할 Post의 ID값 리스트")
+	@NotNull(message = "수정할 게시물 목록을 입력해주세요.")
 	List<Long> postsId
 ) {
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/SinglePostUpdateRequest.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/request/SinglePostUpdateRequest.java
@@ -1,10 +1,12 @@
 package org.mainapp.domain.post.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "게시물 프롬프트 기반 개별 수정 API 요청 본문")
 public record SinglePostUpdateRequest(
 	@Schema(description = "수정에 사용할 프롬프트", example = "이렇게 이렇게 수정해줘")
+	@NotNull(message = "수정에 사용할 프롬프트를 입력해주세요.")
 	String prompt
 ) {
 	public static SinglePostUpdateRequest from(String prompt) {

--- a/application/main-app/src/main/java/org/mainapp/global/filter/JwtAuthenticationFilter.java
+++ b/application/main-app/src/main/java/org/mainapp/global/filter/JwtAuthenticationFilter.java
@@ -55,7 +55,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		// 	responseUtil.setTokensInResponse(response, newAccessToken, newRefreshToken);
 		// }
 
-		String userId = "1";
+		// TODO: 커밋하기 전 1로 변경
+		String userId = "8";
 
 		SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(userId));
 		filterChain.doFilter(request, response);

--- a/application/main-app/src/main/java/org/mainapp/global/filter/JwtAuthenticationFilter.java
+++ b/application/main-app/src/main/java/org/mainapp/global/filter/JwtAuthenticationFilter.java
@@ -55,8 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		// 	responseUtil.setTokensInResponse(response, newAccessToken, newRefreshToken);
 		// }
 
-		// TODO: 커밋하기 전 1로 변경
-		String userId = "8";
+		String userId = "1";
 
 		SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(userId));
 		filterChain.doFilter(request, response);

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/AgentPersonalSetting.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/AgentPersonalSetting.java
@@ -63,4 +63,20 @@ public class AgentPersonalSetting {
 			.customTone(customTone)
 			.build();
 	}
+
+	public void updateDomain(String domain) {
+		this.domain = domain;
+	}
+
+	public void updateIntroduction(String introduction) {
+		this.introduction = introduction;
+	}
+
+	public void updateTone(AgentToneType tone) {
+		this.tone = tone;
+	}
+
+	public void updateCustomTone(String customTone) {
+		this.customTone = customTone;
+	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #172 

## 📌 작업 내용 및 특이사항
사용자가 연동한 SNS 계정의 개인화 설정을 변경하는 API를 구현했습니다.
- 설정된 필드만 변경되도록 필드별로 null 체크를 수행한 뒤 변경하도록 구현했습니다.
- 각 필드별로 정해진 글자수 제한에 대한 검증을 적용했습니다.
- 변경 내용에 대한 저장은 AgentTransactionService를 사용하도록 구현했습니다.