### PR TITLE
[#173] Feature: 계정별 게시물 그룹 목록 조회 API 구현

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import org.mainapp.domain.post.controller.request.UpdatePostContentRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
 import org.mainapp.domain.post.controller.response.CreatePostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupPostsResponse;
+import org.mainapp.domain.post.controller.response.GetPostGroupsResponse;
 import org.mainapp.domain.post.controller.response.PromptHistoriesResponse;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
 import org.mainapp.domain.post.service.PostPromptHistoryService;
@@ -81,7 +82,11 @@ public class PostController {
 		return ResponseEntity.ok(postService.createAdditionalPosts(agentId, postGroupId, limit));
 	}
 
-	// @Operation(summary = "계정별 게시물 그룹 목록 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹 목록을 조회합니다.")
+	@Operation(summary = "계정별 게시물 그룹 목록 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹 목록을 조회합니다.")
+	@GetMapping
+	public ResponseEntity<GetPostGroupsResponse> getPostGroupsByAgent(@PathVariable Long agentId) {
+		return ResponseEntity.ok().build();
+	}
 
 	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")
 	@GetMapping("/{postGroupId}/posts")

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -81,6 +81,8 @@ public class PostController {
 		return ResponseEntity.ok(postService.createAdditionalPosts(agentId, postGroupId, limit));
 	}
 
+	// @Operation(summary = "계정별 게시물 그룹 목록 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹 목록을 조회합니다.")
+
 	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")
 	@GetMapping("/{postGroupId}/posts")
 	public ResponseEntity<GetPostGroupPostsResponse> getPostsByPostGroup(

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -85,7 +85,7 @@ public class PostController {
 	@Operation(summary = "계정별 게시물 그룹 목록 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹 목록을 조회합니다.")
 	@GetMapping
 	public ResponseEntity<GetPostGroupsResponse> getPostGroupsByAgent(@PathVariable Long agentId) {
-		return ResponseEntity.ok().build();
+		return ResponseEntity.ok(postService.getPostGroups(agentId));
 	}
 
 	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetPostGroupsResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetPostGroupsResponse.java
@@ -1,0 +1,24 @@
+package org.mainapp.domain.post.controller.response;
+
+import java.util.List;
+
+import org.domainmodule.postgroup.entity.PostGroup;
+import org.mainapp.domain.post.controller.response.type.PostGroupResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계정별 게시물 그룹 목록 조회 API 응답 본문")
+public record GetPostGroupsResponse(
+	@Schema(description = "게시물 그룹 목록")
+	List<PostGroupResponse> postGroups
+) {
+
+	public static GetPostGroupsResponse from(List<PostGroup> postGroups) {
+		List<PostGroupResponse> postGroupResponses = postGroups.stream()
+			.map(PostGroupResponse::from)
+			.toList();
+		return new GetPostGroupsResponse(
+			postGroupResponses
+		);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/type/PostGroupResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/type/PostGroupResponse.java
@@ -1,5 +1,6 @@
 package org.mainapp.domain.post.controller.response.type;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.domainmodule.postgroup.entity.PostGroup;
@@ -21,6 +22,9 @@ public class PostGroupResponse {
 
 	@Schema(description = "게시물 그룹 id", example = "1")
 	private Long id;
+
+	@Schema(description = "게시물 그룹 생성 일시", example = "2025-01-01T00:00:00.000Z")
+	private LocalDateTime createdAt;
 
 	@Schema(description = "게시물 그룹의 주제", example = "점심 메뉴 추천")
 	private String topic;
@@ -46,6 +50,9 @@ public class PostGroupResponse {
 	@Schema(description = "게시물 그룹의 생성 횟수 제한 도달 여부", example = "false")
 	private Boolean eof;
 
+	@Schema(description = "게시물 그룹 썸네일 이미지", example = "https://~")
+	private String thumbnailImage;
+
 	public static PostGroupResponse from(PostGroup postGroup) {
 		List<PostGroupImageResponse> postGroupImages = postGroup.getPostGroupImages().stream()
 			.map(PostGroupImageResponse::from)
@@ -53,6 +60,7 @@ public class PostGroupResponse {
 		boolean eof = (postGroup.getGenerationCount() >= PostGenerationCount.MAX_POST_GENERATION_COUNT);
 		return new PostGroupResponse(
 			postGroup.getId(),
+			postGroup.getCreatedAt(),
 			postGroup.getTopic(),
 			postGroup.getPurpose(),
 			postGroup.getReference(),
@@ -60,7 +68,8 @@ public class PostGroupResponse {
 			postGroupImages,
 			postGroup.getLength(),
 			postGroup.getContent(),
-			eof
+			eof,
+			postGroup.getThumbnailImage()
 		);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -21,6 +21,7 @@ import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
 import org.mainapp.domain.post.controller.request.type.UpdatePostsRequestItem;
 import org.mainapp.domain.post.controller.response.CreatePostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupPostsResponse;
+import org.mainapp.domain.post.controller.response.GetPostGroupsResponse;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
 import org.mainapp.domain.post.exception.PostErrorCode;
 import org.mainapp.global.constants.PostGenerationCount;
@@ -84,6 +85,18 @@ public class PostService {
 			case NEWS -> postCreateService.createAdditionalPostsByNews(postGroup, limit, order);
 			case IMAGE -> postCreateService.createAdditionalPostsByImage(postGroup, limit, order);
 		};
+	}
+
+	/**
+	 * 사용자 연동 SNS 계정별 게시물 그룹 목록을 반환하는 메서드
+	 */
+	public GetPostGroupsResponse getPostGroups(Long agentId) {
+		// 사용자 인증 정보 및 PostGroup 리스트 조회
+		Long userId = SecurityUtil.getCurrentUserId();
+		List<PostGroup> postGroups = postGroupRepository.findAllByUserIdAndAgentId(userId, agentId);
+
+		// 반환
+		return GetPostGroupsResponse.from(postGroups);
 	}
 
 	/**

--- a/application/main-app/src/main/java/org/mainapp/global/config/WebSecurityConfig.java
+++ b/application/main-app/src/main/java/org/mainapp/global/config/WebSecurityConfig.java
@@ -71,7 +71,7 @@ public class WebSecurityConfig {
 				exceptionHandling
 					.authenticationEntryPoint(customAuthenticationEntryPoint.oAuth2EntryPoint())
 			)
-		.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return http.build();
 	}
@@ -84,6 +84,7 @@ public class WebSecurityConfig {
 		configuration.addAllowedOriginPattern(UrlConstants.LOCAL_DOMAIN_URL);
 		configuration.addAllowedOriginPattern(UrlConstants.PROD_DOMAIN_URL);
 		configuration.addAllowedOriginPattern(UrlConstants.SERVER_DOMAIN_URL);
+		configuration.addAllowedOriginPattern(UrlConstants.DEV_SERVER_DOMAIN_URL);
 		configuration.addAllowedMethod("*");
 		configuration.addAllowedHeader("*");
 		configuration.setAllowCredentials(true);

--- a/application/main-app/src/main/java/org/mainapp/global/constants/UrlConstants.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/UrlConstants.java
@@ -1,9 +1,16 @@
 package org.mainapp.global.constants;
 
 public final class UrlConstants {
-	private UrlConstants() {throw new UnsupportedOperationException("Url상수 인스턴트를 생성할 수 없습니다.");}
+
+	private UrlConstants() {
+		throw new UnsupportedOperationException("Url상수 인스턴트를 생성할 수 없습니다.");
+	}
+
 	// Local 환경 상수
 	public static final String LOCAL_DOMAIN_URL = "http://localhost:3000";
+
+	// Dev 환경 상수
+	public static final String DEV_SERVER_DOMAIN_URL = "https://jumo.im";
 
 	// Prod 환경 상수
 	public static final String PROD_DOMAIN_URL = "https://instd.vercel.app";

--- a/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
@@ -18,5 +18,6 @@ public final class WebSecurityURI {
 	);
 
 	public static final List<String> CORS_ALLOW_URIS =
-		List.of(UrlConstants.LOCAL_DOMAIN_URL, UrlConstants.PROD_DOMAIN_URL, UrlConstants.SERVER_DOMAIN_URL);
+		List.of(UrlConstants.LOCAL_DOMAIN_URL, UrlConstants.PROD_DOMAIN_URL, UrlConstants.SERVER_DOMAIN_URL,
+			UrlConstants.DEV_SERVER_DOMAIN_URL);
 }

--- a/application/main-app/src/main/resources/application.yml
+++ b/application/main-app/src/main/resources/application.yml
@@ -26,3 +26,6 @@ client:
         url: https://api.openai.com/v1/chat/completions
         key: ${OPENAI_API_KEY}
         model: gpt-4o-mini
+
+default-image:
+    post-group: https://instead-dev.s3.ap-northeast-2.amazonaws.com/post-group/default.png

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
@@ -66,9 +66,13 @@ public class PostGroup extends BaseTimeEntity {
 
 	private Integer generationCount;
 
+	private String thumbnailImage;
+
 	@Builder(access = AccessLevel.PRIVATE)
-	private PostGroup(Agent agent, RssFeed feed, String topic, PostGroupPurposeType purpose,
-		PostGroupReferenceType reference, PostGroupLengthType length, String content, Integer generationCount) {
+	private PostGroup(
+		Agent agent, RssFeed feed, String topic, PostGroupPurposeType purpose, PostGroupReferenceType reference,
+		PostGroupLengthType length, String content, Integer generationCount, String thumbnailImage
+	) {
 		this.agent = agent;
 		this.topic = topic;
 		this.purpose = purpose;
@@ -77,6 +81,7 @@ public class PostGroup extends BaseTimeEntity {
 		this.length = length;
 		this.content = content;
 		this.generationCount = generationCount;
+		this.thumbnailImage = thumbnailImage;
 	}
 
 	public static PostGroup createPostGroup(
@@ -87,7 +92,8 @@ public class PostGroup extends BaseTimeEntity {
 		PostGroupReferenceType reference,
 		PostGroupLengthType length,
 		String content,
-		Integer generationCount
+		Integer generationCount,
+		String thumbnailImage
 	) {
 		return PostGroup.builder()
 			.agent(agent)
@@ -98,6 +104,7 @@ public class PostGroup extends BaseTimeEntity {
 			.length(length)
 			.content(content)
 			.generationCount(generationCount)
+			.thumbnailImage(thumbnailImage)
 			.build();
 	}
 

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
@@ -1,5 +1,6 @@
 package org.domainmodule.postgroup.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.domainmodule.postgroup.entity.PostGroup;
@@ -7,6 +8,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 public interface PostGroupRepository extends JpaRepository<PostGroup, Long> {
+
+	@Query("""
+			select pg from PostGroup pg
+			join fetch pg.agent
+			join fetch pg.agent.user
+			where pg.agent.user.id = :userId
+			and pg.agent.id = :agentId
+		""")
+	List<PostGroup> findAllByUserIdAndAgentId(Long userId, Long agentId);
 
 	@Query("""
 			select pg from PostGroup pg


### PR DESCRIPTION
## 🌱 관련 이슈
- close #173 

## 📌 작업 내용 및 특이사항

### 1. PostGroup 엔티티에 thumbnailImage 필드 추가
게시물 그룹에서 썸네일을 관리하기 위해 thumbnail_image 컬럼을 추가하게 되었기 때문에, 이에 맞춰 엔티티를 수정했습니다.


### 2. 기존 게시물 그룹 생성 로직에 썸네일 이미지 지정하는 로직 추가
게시물 그룹이 생성될 때, 썸네일 이미지를 지정하도록 해당 로직을 추가했습니다.

application.yml 파일에 default-image 경로를 지정해두었습니다.
```java
default-image:
    post-group: https://instead-dev.s3.ap-northeast-2.amazonaws.com/post-group/default.png
```

PostCreateService에서 기본 썸네일 이미지 프로퍼티를 받아와 이를 지정하도록 구현했습니다.
- 이미지를 참고하는 게시물이 아닌 경우, 기본 이미지를 썸네일로 지정합니다.
- 이미지를 참고하는 게시물의 경우, 요청된 이미지 중 첫 번째 이미지를 썸네일로 지정합니다.
```java
@Service
@RequiredArgsConstructor
public class PostCreateService {

  @Value("${default-image.post-group}")
  private String postGroupDefaultImage;

  public CreatePostsResponse createPostsWithoutRef(Agent agent, CreatePostsRequest request, Integer limit) {
    ...
    // PostGroup 엔티티 생성
    PostGroup postGroup = PostGroup.createPostGroup(agent, null, request.getTopic(), request.getPurpose(),
	request.getReference(), request.getLength(), request.getContent(), 1, postGroupDefaultImage);
    ...
  }

  public CreatePostsResponse createPostsByNews(Agent agent, CreatePostsRequest request, Integer limit) {
    ...
    // PostGroup 엔티티 생성
    PostGroup postGroup = PostGroup.createPostGroup(agent, rssFeed, request.getTopic(), request.getPurpose(),
	request.getReference(), request.getLength(), request.getContent(), 1, postGroupDefaultImage);
    ...
  }

  public CreatePostsResponse createPostsByImage(Agent agent, CreatePostsRequest request, Integer limit) {
    ...
    // PostGroup 엔티티 생성
    PostGroup postGroup = PostGroup.createPostGroup(
	agent, null, request.getTopic(), request.getPurpose(), request.getReference(), request.getLength(),
	request.getContent(), 1, request.getImageUrls().get(0)
    );
    ...
  }
```

### 3. 계정별 게시물 그룹 목록 조회 API 구현
위 작업사항을 바탕으로, 사용자가 연동한 SNS 계정의 게시물 그룹 목록을 조회하는 API를 구현했습니다.
또한 PostGroupResponse의 필드를 추가했습니다.
- createdAt: 홈 화면에서 보여질 게시물 그룹 생성 일시
- thumbnailImage: 홈 화면에서 보여질 게시물 그룹 썸네일 이미지

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
- 게시물 생성 시 게시물 그룹도 함께 생성되기 때문에 기존에 post 도메인에서 게시물 그룹도 관리하고 있었는데, 이를 지금 당장 분리하기는 애매한 것 같아서 이번 API도 post 도메인에 구현했어요.
- 게시물 그룹 생성 시, 이미지를 참고하는 경우 이미지 목록의 첫 번째 이미지를 썸네일로 지정하도록 구현했어요. 이때 기존 로직에 이미지 리스트가 비어있을 경우에 대한 예외처리가 없어서 추가했습니다.