### PR TITLE
[#180] Refactor: 그룹별 게시물 조회 시 Post가 없는 Status는 빈 리스트로 리턴

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/auth/service/AuthServiceImpl.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/auth/service/AuthServiceImpl.java
@@ -37,9 +37,15 @@ public class AuthServiceImpl implements AuthService {
 	// 로그인
 	private Optional<User> findUserByOAuthInfo(OAuth2UserInfo oAuth2Response) {
 		ProviderType providerType = ProviderType.fromValue(oAuth2Response.getProvider());
+
 		return oauthRepository.findByProviderAndProviderId(providerType, oAuth2Response.getProviderId())
-			.map(Oauth::getUser);
+			.map(Oauth::getUser)
+			.map(user -> {
+				tokenService.generateRefreshToken(user.getId());
+				return user;
+			});
 	}
+
 
 	// 회원가입
 	private User registerUser(OAuth2UserInfo oAuth2Response) {

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetPostGroupPostsResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetPostGroupPostsResponse.java
@@ -3,7 +3,7 @@ package org.mainapp.domain.post.controller.response;
 import java.util.List;
 import java.util.Map;
 
-import org.domainmodule.post.entity.Post;
+import org.domainmodule.post.entity.type.PostStatusType;
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.mainapp.domain.post.controller.response.type.PostGroupResponse;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
@@ -22,9 +22,9 @@ public class GetPostGroupPostsResponse {
 	private PostGroupResponse postGroup;
 
 	@Schema(description = "게시물 그룹에 해당하는 게시물 목록")
-	private Map<String, List<PostResponse>> posts;
+	private Map<PostStatusType, List<PostResponse>> posts;
 
-	public static GetPostGroupPostsResponse of(PostGroup postGroup,Map<String, List<PostResponse>> posts) {
+	public static GetPostGroupPostsResponse of(PostGroup postGroup,Map<PostStatusType, List<PostResponse>> posts) {
 		return new GetPostGroupPostsResponse(PostGroupResponse.from(postGroup), posts);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -1,8 +1,11 @@
 package org.mainapp.domain.post.service;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.domainmodule.agent.entity.Agent;
@@ -113,9 +116,10 @@ public class PostService {
 		List<Post> posts = postRepository.findAllWithImagesByPostGroup(postGroup);
 
 		// 상태별로 그룹화
-		Map<String, List<PostResponse>> groupedPosts = posts.stream()
+		Map<PostStatusType, List<PostResponse>> groupedPosts = initializeEmptyStatusMap();
+		posts.stream()
 			.map(PostResponse::from)
-			.collect(Collectors.groupingBy(post -> post.getStatus().name()));
+			.forEach(post -> groupedPosts.get(post.getStatus()).add(post));
 
 		// displayOrder 오름차순으로 정렬
 		groupedPosts.forEach((status, list) ->
@@ -123,6 +127,17 @@ public class PostService {
 		);
 
 		return GetPostGroupPostsResponse.of(postGroup, groupedPosts);
+	}
+
+	/**
+	 * PostStatusType을 포함하는 빈 리스트 생성
+	 */
+	private Map<PostStatusType, List<PostResponse>> initializeEmptyStatusMap() {
+		return EnumSet.allOf(PostStatusType.class).stream()
+			.collect(Collectors.toMap(
+				Function.identity(),
+				status -> new ArrayList<>()
+			));
 	}
 
 	/**


### PR DESCRIPTION
## 🌱 관련 이슈
- close #180 

## 📌 작업 내용 및 특이사항
아래와 같이 READY_TO_UPLOAD 의 Post가 없더라도 빈 리스트로 반환 (민성님 요청사항)
```java
posts: {
    GENERATED: [
      { id: 3, displayOrder: 1 ... },
      { id: 1, displayOrder: 2 ... },
    ],
    EDITING: [
      { id: 2, displayOrder: 1 ... },
      { id: 4, displayOrder: 2 ... },
      { id: 5, displayOrder: 3 ... },
    ],
    READY_TO_UPLOAD: [],
    ...
  }
```

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


