### PR TITLE
[#185] Feature: 계정별 예약 게시물 목록 조회 API

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -210,4 +210,18 @@ public class PostController {
 		postService.deletePosts(agentId, postGroupId, postIds);
 		return ResponseEntity.noContent().build();
 	}
+
+	@Operation(
+		summary = "계정별 예약 게시물 조회 API",
+		description = """
+			sns 계정별 업로드가 예약된 상태(UPLOAD_RESERVED)인 게시물 목록을 조회합니다.
+			"""
+	)
+	@GetMapping("/{postGroupId}/posts/upload-reserved")
+	public ResponseEntity<List<PostResponse>> uploadReservedPosts(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId
+	) {
+		return ResponseEntity.ok(postService.getUploadReservedPosts(agentId, postGroupId));
+	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -8,6 +8,7 @@ import org.mainapp.domain.post.controller.request.SinglePostUpdateRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostContentRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
 import org.mainapp.domain.post.controller.response.CreatePostsResponse;
+import org.mainapp.domain.post.controller.response.GetAgentReservedPostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupPostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupsResponse;
 import org.mainapp.domain.post.controller.response.PromptHistoriesResponse;
@@ -213,15 +214,13 @@ public class PostController {
 
 	@Operation(
 		summary = "계정별 예약 게시물 조회 API",
-		description = """
-			sns 계정별 업로드가 예약된 상태(UPLOAD_RESERVED)인 게시물 목록을 조회합니다.
-			"""
+		description = "sns 계정별 업로드가 예약된 상태(UPLOAD_RESERVED)인 게시물 목록을 조회합니다."
 	)
 	@GetMapping("/{postGroupId}/posts/upload-reserved")
-	public ResponseEntity<List<PostResponse>> uploadReservedPosts(
+	public ResponseEntity<GetAgentReservedPostsResponse> getAgentReservedPosts(
 		@PathVariable Long agentId,
 		@PathVariable Long postGroupId
 	) {
-		return ResponseEntity.ok(postService.getUploadReservedPosts(agentId, postGroupId));
+		return ResponseEntity.ok(postService.getAgentReservedPosts(agentId, postGroupId));
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetAgentReservedPostsResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetAgentReservedPostsResponse.java
@@ -1,0 +1,22 @@
+package org.mainapp.domain.post.controller.response;
+
+import java.util.List;
+
+import org.domainmodule.post.entity.Post;
+import org.mainapp.domain.post.controller.response.type.PostResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "계정별 예약 게시물 목록 조회 API 응답 객체")
+public record GetAgentReservedPostsResponse(
+	@Schema(description = "예약 게시물 목록")
+	List<PostResponse> posts
+) {
+
+	public static GetAgentReservedPostsResponse from(List<Post> posts) {
+		List<PostResponse> postResponses = posts.stream()
+			.map(PostResponse::from)
+			.toList();
+		return new GetAgentReservedPostsResponse(postResponses);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -23,6 +23,7 @@ import org.mainapp.domain.post.controller.request.UpdatePostContentRequest;
 import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
 import org.mainapp.domain.post.controller.request.type.UpdatePostsRequestItem;
 import org.mainapp.domain.post.controller.response.CreatePostsResponse;
+import org.mainapp.domain.post.controller.response.GetAgentReservedPostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupPostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupsResponse;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
@@ -271,14 +272,14 @@ public class PostService {
 		}
 	}
 
-	public List<PostResponse> getUploadReservedPosts(Long agentId, Long postGroupId) {
+	public GetAgentReservedPostsResponse getAgentReservedPosts(Long agentId, Long postGroupId) {
 		Long userId = SecurityUtil.getCurrentUserId();
 		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
-		return postTransactionService.getPostsByGroupAndStatus(postGroup, PostStatusType.UPLOAD_RESERVED)
-			.stream()
-			.map(PostResponse::from)
-			.toList();
+		List<Post> posts = postTransactionService.getPostsByGroupAndStatus(postGroup,
+			PostStatusType.UPLOAD_RESERVED);
+
+		return GetAgentReservedPostsResponse.from(posts);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -270,4 +270,15 @@ public class PostService {
 			throw new CustomException(PostErrorCode.INVALID_DELETING_POST_STATUS);
 		}
 	}
+
+	public List<PostResponse> getUploadReservedPosts(Long agentId, Long postGroupId) {
+		Long userId = SecurityUtil.getCurrentUserId();
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
+
+		return postTransactionService.getPostsByGroupAndStatus(postGroup, PostStatusType.UPLOAD_RESERVED)
+			.stream()
+			.map(PostResponse::from)
+			.toList();
+	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostTransactionService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostTransactionService.java
@@ -122,6 +122,11 @@ public class PostTransactionService {
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
 	}
 
+	@Transactional(readOnly = true)
+	public List<Post> getPostsByGroupAndStatus(PostGroup postGroup, PostStatusType status) {
+		return postRepository.findAllByPostGroupAndStatus(postGroup, status);
+	}
+
 	// TODO: 하위 서비스인 PostTransactionService에서 상위 서비스인 PostPromptHistoryService 주입받고 있음.
 	@Transactional
 	public PostResponse updateSinglePostAndPromptyHistory(Post post, String prompt, SummaryContentFormat newContent) {

--- a/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/repository/PostRepository.java
@@ -67,4 +67,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 		    limit 1
 		""")
 	Optional<Post> findLastGeneratedPost(PostGroup postGroup, PostStatusType status);
+
+	// postGroupt에서 특정 status를 가진 Post리스트 반환
+	List<Post> findAllByPostGroupAndStatus(PostGroup postGroup, PostStatusType status);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #185

## 📌 작업 내용 및 특이사항
- 계정별 예약중인 상태인 게시물(UPLOAD_RESERVED) 리스트 조회

```java
	@Transactional(readOnly = true)
	public List<Post> getPostsByGroupAndStatus(PostGroup postGroup, PostStatusType status) {
		return postRepository.findAllByPostGroupAndStatus(postGroup, status);
	}
```
위의 메서드를 통해 group안의 status를 가진 post 리스트 조회

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


