### PR TITLE
[#187] Feature: 단일 게시물 상세조회 API

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -223,4 +223,17 @@ public class PostController {
 	) {
 		return ResponseEntity.ok(postService.getAgentReservedPosts(agentId, postGroupId));
 	}
+
+	@Operation(
+		summary = "개별 게시물 상세조회 API",
+		description = "게시물 클릭 시 단건 게시물에 대한 상세정보를 조회합니다."
+	)
+	@GetMapping("/{postGroupId}/posts/{postId}")
+	public ResponseEntity<PostResponse> getPostDetails(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@PathVariable Long postId
+	) {
+		return ResponseEntity.ok(postService.getPostDetails(agentId, postGroupId, postId));
+	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -272,6 +272,9 @@ public class PostService {
 		}
 	}
 
+	/**
+	 * 예약중인 게시물 조회
+	 */
 	public GetAgentReservedPostsResponse getAgentReservedPosts(Long agentId, Long postGroupId) {
 		Long userId = SecurityUtil.getCurrentUserId();
 		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
@@ -281,5 +284,19 @@ public class PostService {
 			PostStatusType.UPLOAD_RESERVED);
 
 		return GetAgentReservedPostsResponse.from(posts);
+	}
+
+	/**
+	 * 단일 Post 상세내용 조회
+	 */
+	public PostResponse getPostDetails(Long agentId, Long postGroupId, Long postId) {
+		Long userId = SecurityUtil.getCurrentUserId();
+
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
+
+		Post post = postRepository.findByPostGroupAndId(postGroup, postId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
+		return PostResponse.from(post);
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #187 

## 📌 작업 내용 및 특이사항
- 단일 게시물 상세 조회 API
- 기존 PostResponse를 이용해서 단일 게시물 조회

## 🧐 고민한 점
- 현재 post를 조회하기전에 PostGroup을 조회하고, Post를 조회하는 방식을 사용해서 총 쿼리를 2번 날리는 중이에요.
- 그런데 단일 게시물 상세 조회같은 API는 요청횟수가 많을 것 같은데 쿼리 1번으로 post를 조회하는게 좋을까요??

쿼리 1번으로 조회 시
- 단점: 예외처리를 세부적으로 못함 ( agent가 없는경우, postGroup이 없는 경우를 구분을 못하는 문제)
쿼리 2번으로 조회 시
- 단점: 성능상 쿼리2번을 날리기에 좋지않을 것 같음

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


