### PR TITLE
[#191] Feature: 게시물 생성 및 수정 시 개인화 설정에 따라 InstructionPrompt를 동적으로 구성하도록 변경

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostCreateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostCreateService.java
@@ -377,9 +377,9 @@ public class PostCreateService {
 	 */
 	private List<ChatCompletionResponse> generatePostsWithoutRef(GeneratePostsVo vo, List<String> topics) {
 		// 프롬프트 생성: Instruction + 주제 Prompt 리스트
-		String instructionPrompt = createPostPromptTemplate.getInstruction();
+		String instructionPrompt = createPostPromptTemplate.getTempInstructionPrompt();
 		List<String> topicPrompts = topics.stream()
-			.map(topic -> createPostPromptTemplate.getBasicTopicPrompt(topic, vo.purpose(), vo.length(), vo.content()))
+			.map(topic -> createPostPromptTemplate.getTopicPrompt(topic, vo.purpose(), vo.length(), vo.content()))
 			.toList();
 
 		// 게시물 생성
@@ -406,8 +406,8 @@ public class PostCreateService {
 	 */
 	private List<ChatCompletionResponse> generatePostsByNews(GeneratePostsVo vo, FeedPagingResult feedPagingResult) {
 		// 프롬프트 생성
-		String instructionPrompt = createPostPromptTemplate.getInstruction();
-		String topicPrompt = createPostPromptTemplate.getBasicTopicPrompt(
+		String instructionPrompt = createPostPromptTemplate.getTempInstructionPrompt();
+		String topicPrompt = createPostPromptTemplate.getTopicPrompt(
 			vo.topic(), vo.purpose(), vo.length(), vo.content());
 		List<String> refPrompts = feedPagingResult.getFeedItems().stream()
 			.map(news -> createPostPromptTemplate.getNewsRefPrompt(news.getContentSummary(), news.getContent()))
@@ -439,9 +439,9 @@ public class PostCreateService {
 	 */
 	private List<ChatCompletionResponse> generatePostsByImage(GeneratePostsVo vo, List<String> topics) {
 		// 프롬프트 생성
-		String instructionPrompt = createPostPromptTemplate.getInstruction();
+		String instructionPrompt = createPostPromptTemplate.getTempInstructionPrompt();
 		List<String> topicPrompts = topics.stream()
-			.map(topic -> createPostPromptTemplate.getBasicTopicPrompt(topic, vo.purpose(), vo.length(), vo.content()))
+			.map(topic -> createPostPromptTemplate.getTopicPrompt(topic, vo.purpose(), vo.length(), vo.content()))
 			.toList();
 		String imageRefPrompt = createPostPromptTemplate.getImageRefPrompt();
 

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostPromptUpdateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostPromptUpdateService.java
@@ -82,7 +82,7 @@ public class PostPromptUpdateService {
 
 	private ChatCompletionResponse applyPrompt(String prompt, String previousResponse) {
 		// 프롬프트 생성: Instruction
-		String instructionPrompt = createPostPromptTemplate.getInstruction();
+		String instructionPrompt = createPostPromptTemplate.getTempInstructionPrompt();
 
 		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(
 			openAiModel, summaryContentSchema.getResponseFormat(), 1, null)

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostPromptUpdateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostPromptUpdateService.java
@@ -3,7 +3,9 @@ package org.mainapp.domain.post.service;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.domainmodule.agent.entity.AgentPersonalSetting;
 import org.domainmodule.post.entity.Post;
+import org.domainmodule.postgroup.entity.PostGroup;
 import org.mainapp.domain.post.controller.request.MultiplePostUpdateRequest;
 import org.mainapp.domain.post.controller.request.SinglePostUpdateRequest;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
@@ -42,10 +44,16 @@ public class PostPromptUpdateService {
 	/**
 	 * 단일 게시물을 prompt를 적용하여 업데이트하는 메서드
 	 */
+	// TODO: 트랜잭션 내에서 API 호출하지 않도록 변경
 	@Transactional
-	public PostResponse updateSinglePostByPrompt(Post post, SinglePostUpdateRequest request) {
+	public PostResponse updateSinglePostByPrompt(
+		AgentPersonalSetting agentPersonalSetting, PostGroup postGroup, Post post, SinglePostUpdateRequest request
+	) {
 		// 프롬프트 적용
-		SummaryContentFormat newContent = updatePostContentByPrompt(post, request.prompt());
+		SummaryContentFormat newContent = updatePostContentByPrompt(
+			agentPersonalSetting, postGroup, post, request.prompt()
+		);
+
 		// DB값 업데이트
 		return postTransactionService.updateSinglePostAndPromptyHistory(post, request.prompt(), newContent);
 	}
@@ -53,10 +61,14 @@ public class PostPromptUpdateService {
 	/**
 	 * 일괄로 게시물들을 prompt 적용 후 업데이트 하는 메서드
 	 */
-	public List<PostResponse> updateMultiplePostsByPrompt(List<Post> posts, MultiplePostUpdateRequest request) {
+	public List<PostResponse> updateMultiplePostsByPrompt(
+		AgentPersonalSetting agentPersonalSetting, PostGroup postGroup, List<Post> posts,
+		MultiplePostUpdateRequest request
+	) {
 		// Post 리스트 업그레이드 비동기 작업 수행
 		List<CompletableFuture<SummaryContentFormat>> futures = posts.stream()
-			.map(post -> CompletableFuture.supplyAsync(() -> updatePostContentByPrompt(post, request.prompt())))
+			.map(post -> CompletableFuture
+				.supplyAsync(() -> updatePostContentByPrompt(agentPersonalSetting, postGroup, post, request.prompt())))
 			.toList();
 
 		// 모든 프롬프트 처리 완료 대기
@@ -68,11 +80,20 @@ public class PostPromptUpdateService {
 		return postTransactionService.updateMutiplePostAndPromptyHistory(posts, request.prompt(), newContents);
 	}
 
-	private SummaryContentFormat updatePostContentByPrompt(Post post, String prompt) {
+	private SummaryContentFormat updatePostContentByPrompt(
+		AgentPersonalSetting agentPersonalSetting, PostGroup postGroup, Post post, String updatePrompt
+	) {
 		String previousResponse = post.getContent();
 
+		// Instruction 및 Topic 프롬프트 생성
+		String instructionPrompt = createPostPromptTemplate.getInstructionPrompt(
+			agentPersonalSetting.getDomain(), agentPersonalSetting.getIntroduction(),
+			agentPersonalSetting.getTone(), agentPersonalSetting.getCustomTone());
+		String topicPrompt = createPostPromptTemplate.getTopicPrompt(
+			postGroup.getTopic(), postGroup.getPurpose(), postGroup.getLength(), postGroup.getContent());
+
 		// ChatGPT 프롬프트 실행
-		ChatCompletionResponse result = applyPrompt(prompt, previousResponse);
+		ChatCompletionResponse result = applyPrompt(instructionPrompt, topicPrompt, updatePrompt, previousResponse);
 
 		// 결과 파싱하여 새로운 요약 + 본문 생성
 		return parseSummaryContentFormat(
@@ -80,15 +101,15 @@ public class PostPromptUpdateService {
 		);
 	}
 
-	private ChatCompletionResponse applyPrompt(String prompt, String previousResponse) {
-		// 프롬프트 생성: Instruction
-		String instructionPrompt = createPostPromptTemplate.getTempInstructionPrompt();
-
+	private ChatCompletionResponse applyPrompt(
+		String instructionPrompt, String topicPrompt, String updatePrompt, String previousResponse
+	) {
 		ChatCompletionRequest chatCompletionRequest = new ChatCompletionRequest(
 			openAiModel, summaryContentSchema.getResponseFormat(), 1, null)
 			.addDeveloperMessage(instructionPrompt)
+			.addUserTextMessage(topicPrompt)
 			.addAssistantMessage(previousResponse)
-			.addUserTextMessage(prompt);
+			.addUserTextMessage(updatePrompt);
 
 		try {
 			return openAiClient.getChatCompletion(chatCompletionRequest);

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -159,10 +159,14 @@ public class PostService {
 		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
+		// Agent 조회
+		AgentPersonalSetting agentPersonalSetting = agentPersonalSettingRepository.findByUserIdAndAgentId(userId,
+			agentId).orElseThrow(() -> new CustomException(AgentErrorCode.AGENT_NOT_FOUND));
+
 		// Post 조회
 		Post post = postTransactionService.getPostOrThrow(postGroup, postId);
 
-		return postPromptUpdateService.updateSinglePostByPrompt(post, request);
+		return postPromptUpdateService.updateSinglePostByPrompt(agentPersonalSetting, postGroup, post, request);
 	}
 
 	/**
@@ -176,12 +180,16 @@ public class PostService {
 		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
 
+		// Agent 조회
+		AgentPersonalSetting agentPersonalSetting = agentPersonalSettingRepository.findByUserIdAndAgentId(userId,
+			agentId).orElseThrow(() -> new CustomException(AgentErrorCode.AGENT_NOT_FOUND));
+
 		// Post 리스트 조회
 		List<Post> posts = request.postsId().stream()
 			.map(postId -> postTransactionService.getPostOrThrow(postGroup, postId))
 			.toList();
 
-		return postPromptUpdateService.updateMultiplePostsByPrompt(posts, request);
+		return postPromptUpdateService.updateMultiplePostsByPrompt(agentPersonalSetting, postGroup, posts, request);
 	}
 
 	/**

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/vo/GeneratePostsVo.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/vo/GeneratePostsVo.java
@@ -2,6 +2,8 @@ package org.mainapp.domain.post.service.vo;
 
 import java.util.List;
 
+import org.domainmodule.agent.entity.AgentPersonalSetting;
+import org.domainmodule.agent.entity.type.AgentToneType;
 import org.domainmodule.postgroup.entity.PostGroup;
 import org.domainmodule.postgroup.entity.PostGroupImage;
 import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
@@ -10,6 +12,10 @@ import org.domainmodule.rssfeed.entity.type.FeedCategoryType;
 import org.mainapp.domain.post.controller.request.CreatePostsRequest;
 
 public record GeneratePostsVo(
+	String domain,
+	String introduction,
+	AgentToneType tone,
+	String customTone,
 	String topic,
 	PostGroupPurposeType purpose,
 	PostGroupLengthType length,
@@ -19,8 +25,12 @@ public record GeneratePostsVo(
 	Integer limit
 ) {
 
-	public static GeneratePostsVo of(CreatePostsRequest request, Integer limit) {
+	public static GeneratePostsVo of(AgentPersonalSetting setting, CreatePostsRequest request, Integer limit) {
 		return new GeneratePostsVo(
+			setting.getDomain(),
+			setting.getIntroduction(),
+			setting.getTone(),
+			setting.getCustomTone(),
 			request.getTopic(),
 			request.getPurpose(),
 			request.getLength(),
@@ -31,11 +41,15 @@ public record GeneratePostsVo(
 		);
 	}
 
-	public static GeneratePostsVo of(PostGroup postGroup, Integer limit) {
+	public static GeneratePostsVo of(AgentPersonalSetting setting, PostGroup postGroup, Integer limit) {
 		// PostGroup의 feed가 null인 경우 처리
 		FeedCategoryType newsCategory = (postGroup.getFeed() == null) ? null : postGroup.getFeed().getCategory();
 
 		return new GeneratePostsVo(
+			setting.getDomain(),
+			setting.getIntroduction(),
+			setting.getTone(),
+			setting.getCustomTone(),
 			postGroup.getTopic(),
 			postGroup.getPurpose(),
 			postGroup.getLength(),
@@ -46,7 +60,9 @@ public record GeneratePostsVo(
 		);
 	}
 
-	public static GeneratePostsVo of(PostGroup postGroup, List<PostGroupImage> images, Integer limit) {
+	public static GeneratePostsVo of(
+		AgentPersonalSetting setting, PostGroup postGroup, List<PostGroupImage> images, Integer limit
+	) {
 		// PostGroup의 feed가 null인 경우 처리
 		FeedCategoryType newsCategory = (postGroup.getFeed() == null) ? null : postGroup.getFeed().getCategory();
 
@@ -55,6 +71,10 @@ public record GeneratePostsVo(
 			.toList();
 
 		return new GeneratePostsVo(
+			setting.getDomain(),
+			setting.getIntroduction(),
+			setting.getTone(),
+			setting.getCustomTone(),
 			postGroup.getTopic(),
 			postGroup.getPurpose(),
 			postGroup.getLength(),

--- a/application/main-app/src/main/java/org/mainapp/global/filter/JwtAuthenticationFilter.java
+++ b/application/main-app/src/main/java/org/mainapp/global/filter/JwtAuthenticationFilter.java
@@ -55,7 +55,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		// 	responseUtil.setTokensInResponse(response, newAccessToken, newRefreshToken);
 		// }
 
-		String userId = "1";
+		String userId = "8";
 
 		SecurityContextHolder.getContext().setAuthentication(jwtUtil.getAuthentication(userId));
 		filterChain.doFilter(request, response);

--- a/application/main-app/src/main/java/org/mainapp/openai/prompt/CreatePostPromptTemplate.java
+++ b/application/main-app/src/main/java/org/mainapp/openai/prompt/CreatePostPromptTemplate.java
@@ -9,16 +9,6 @@ import org.springframework.stereotype.Component;
 public class CreatePostPromptTemplate {
 
 	/**
-	 * 계정 기본 정보 Instruction 임시 데이터
-	 */
-	// TODO: 지금은 시연을 위한 임시 데이터를 반환하게 해두었고, 실제 agent 생성하는 기능 추가되면 실제 agent 데이터 기반으로 프롬프트 구성해야 함
-	public String getTempInstructionPrompt() {
-		return
-			"너는 한국의 20대 중반 여성이고, 너의 컨셉에 맞게 SNS에 올릴 게시물을 작성해야 해. 반드시 반말을 사용해서 작성하도록 하고, 너무 딱딱한 말투보다는 부드러운 어투를 사용해. 중간중간 이모지를 사용해도 좋아."
-				+ "답변은 JSON 포맷으로 생성해줘. content에는 게시물의 본문이 들어가고, summary에는 본문의 핵심 내용을 명사형으로 요약한 제목이 들어가야 해.";
-	}
-
-	/**
 	 * 계정 기본 정보 Instruction.
 	 * 에이전트의 정보를 받아서 기본 정보에 대한 Instruction을 생성
 	 */
@@ -45,8 +35,9 @@ public class CreatePostPromptTemplate {
 		} else if (customTone != null && tone == AgentToneType.CUSTOM) {
 			prompt
 				.append("게시물을 생성할 때 말투는 다음과 같이 사용해야 해. ")
-				.append(customTone);
+				.append(customTone).append("\n");
 		}
+		prompt.append("여기까지 너가 관리해야 할 계정에 대한 설정이야. 이 설정을 바탕으로 게시물 내용을 생성해야 해.\n\n");
 
 		return prompt.toString();
 	}

--- a/application/main-app/src/main/java/org/mainapp/openai/prompt/CreatePostPromptTemplate.java
+++ b/application/main-app/src/main/java/org/mainapp/openai/prompt/CreatePostPromptTemplate.java
@@ -1,5 +1,6 @@
 package org.mainapp.openai.prompt;
 
+import org.domainmodule.agent.entity.type.AgentToneType;
 import org.domainmodule.postgroup.entity.type.PostGroupLengthType;
 import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
 import org.springframework.stereotype.Component;
@@ -8,21 +9,53 @@ import org.springframework.stereotype.Component;
 public class CreatePostPromptTemplate {
 
 	/**
-	 * 계정 기본 정보 Instruction.
-	 * 에이전트의 정보를 받아서 기본 정보에 대한 Instruction을 생성
+	 * 계정 기본 정보 Instruction 임시 데이터
 	 */
-	// TODO: 지금은 시연을 위한 더미 데이터를 반환하게 해두었고, 실제 agent 생성하는 기능 추가되면 실제 agent 데이터 기반으로 프롬프트 구성해야 함
-	public String getInstruction() {
+	// TODO: 지금은 시연을 위한 임시 데이터를 반환하게 해두었고, 실제 agent 생성하는 기능 추가되면 실제 agent 데이터 기반으로 프롬프트 구성해야 함
+	public String getTempInstructionPrompt() {
 		return
 			"너는 한국의 20대 중반 여성이고, 너의 컨셉에 맞게 SNS에 올릴 게시물을 작성해야 해. 반드시 반말을 사용해서 작성하도록 하고, 너무 딱딱한 말투보다는 부드러운 어투를 사용해. 중간중간 이모지를 사용해도 좋아."
 				+ "답변은 JSON 포맷으로 생성해줘. content에는 게시물의 본문이 들어가고, summary에는 본문의 핵심 내용을 명사형으로 요약한 제목이 들어가야 해.";
 	}
 
 	/**
+	 * 계정 기본 정보 Instruction.
+	 * 에이전트의 정보를 받아서 기본 정보에 대한 Instruction을 생성
+	 */
+	public String getInstructionPrompt(
+		String domain,
+		String introduction,
+		AgentToneType tone,
+		String customTone
+	) {
+		StringBuilder prompt = new StringBuilder();
+
+		prompt.append("너는 SNS 계정을 관리하는 역할이고, 지금부터 소개해줄 계정의 컨셉에 맞게 게시물을 생성해야 해.\n");
+		if (introduction != null) {
+			prompt.append("계정의 전체적인 소개를 해줄게. ").append(introduction).append("\n");
+		}
+		if (domain != null) {
+			prompt.append("계정의 다룰 분야는 다음과 같아. ").append(domain).append("\n");
+		}
+		if (tone != null && tone != AgentToneType.CUSTOM) {
+			prompt
+				.append("게시물을 생성할 때 말투는 ")
+				.append(tone.getSuffix()).append("와 같이 ")
+				.append(tone.getValue()).append("을 사용해야 해.\n");
+		} else if (customTone != null && tone == AgentToneType.CUSTOM) {
+			prompt
+				.append("게시물을 생성할 때 말투는 다음과 같이 사용해야 해. ")
+				.append(customTone);
+		}
+
+		return prompt.toString();
+	}
+
+	/**
 	 * 게시물 그룹에 설정된 주제 Prompt.
 	 * 게시물 그룹의 정보를 받아서 게시물 주제에 대한 Prompt를 생성
 	 */
-	public String getBasicTopicPrompt(
+	public String getTopicPrompt(
 		String topic,
 		PostGroupPurposeType purpose,
 		PostGroupLengthType length,

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentToneType.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/type/AgentToneType.java
@@ -1,5 +1,16 @@
 package org.domainmodule.agent.entity.type;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum AgentToneType {
-	CASUAL, LESS_FORMAL, MORE_FORMAL, CUSTOM
+	CASUAL("반말", "~해"),
+	LESS_FORMAL("가벼운 존댓말", "~해요"),
+	MORE_FORMAL("엄격한 존댓말", "~합니다"),
+	CUSTOM(null, null);
+
+	private final String value;
+	private final String suffix;
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #191 

## 📌 작업 내용 및 특이사항

### 1. CreatePostPromptTemplate에 getInstructionPrompt 변경
기존 임시로 설정되어 있던 getInstructionPrompt 메서드를, 개인화 설정 데이터에 따라 동적으로 프롬프트를 구성하도록 변경했습니다.
```java
public String getInstructionPrompt(
  String domain,
  String introduction,
  AgentToneType tone,
  String customTone
) {
  StringBuilder prompt = new StringBuilder();

  prompt.append("너는 SNS 계정을 관리하는 역할이고, 지금부터 소개해줄 계정의 컨셉에 맞게 게시물을 생성해야 해.\n");
  if (introduction != null) {
    prompt.append("계정의 전체적인 소개를 해줄게. ").append(introduction).append("\n");
  }
  if (domain != null) {
    prompt.append("계정의 다룰 분야는 다음과 같아. ").append(domain).append("\n");
  }
  if (tone != null && tone != AgentToneType.CUSTOM) {
    prompt
      .append("게시물을 생성할 때 말투는 ")
      .append(tone.getSuffix()).append("와 같이 ")
      .append(tone.getValue()).append("을 사용해야 해.\n");
  } else if (customTone != null && tone == AgentToneType.CUSTOM) {
    prompt
      .append("게시물을 생성할 때 말투는 다음과 같이 사용해야 해. ")
      .append(customTone).append("\n");
  }
  prompt.append("여기까지 너가 관리해야 할 계정에 대한 설정이야. 이 설정을 바탕으로 게시물 내용을 생성해야 해.\n\n");

  return prompt.toString();
}
```

### 2. 게시물 생성 및 수정 로직 변경
PostCreateService와 PostPromptUpdateService에서 instruction 프롬프트를 생성하는 부분을 변경된 메서드에 맞게 변경했습니다.

### 3. 게시물 프롬프트 기반 수정 기능 버그 수정
기존 게시물 프롬프트 기반 수정 기능 관련 메서드에서, 게시물 그룹의 설정을 가져오지 않고 계정 설정만으로 게시물을 수정하도록 구현되어 있던 부분을 발견했습니다. 해당 메서드에서 게시물 그룹의 설정을 가져오고 프롬프트로 추가하도록 변경했습니다.

## 🧐 고민한 점 & 🚀 리뷰 해줬으면 하는 부분
- 프롬프트 기반 수정 기능에서 일단 게시물 그룹 설정만 프롬프트로 추가했는데, 참고자료가 있는 경우 이에 대한 프롬프트도 추가해야 할지 고민입니다.