### PR TITLE
[#196] Refactor: 구글, 트위터 로그인 url PUBLIC_URIS에서 제거

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
@@ -9,11 +9,9 @@ import lombok.NoArgsConstructor;
 public final class WebSecurityURI {
 
 	public static final List<String> PUBLIC_URIS = List.of(
-		"/login/oauth2/code/google",
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/swagger-resources/**",
-		"/twitter/**",
 		"/common/health/**"
 	);
 


### PR DESCRIPTION
## 🌱 관련 이슈
- close #196 

## 📌 작업 내용 및 특이사항
- PUBLIC_URIS에서 google, twitter jwt 필터링 거치도록 설정

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


