### PR TITLE
[#201] Feature: 게시물 그룹 조회 및 게시물 그룹 주제 조회 API 구현

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -83,31 +83,6 @@ public class PostController {
 		return ResponseEntity.ok(postService.createAdditionalPosts(agentId, postGroupId, limit));
 	}
 
-	@Operation(summary = "계정별 게시물 그룹 목록 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹 목록을 조회합니다.")
-	@GetMapping
-	public ResponseEntity<GetPostGroupsResponse> getPostGroupsByAgent(@PathVariable Long agentId) {
-		return ResponseEntity.ok(postService.getPostGroups(agentId));
-	}
-
-	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")
-	@GetMapping("/{postGroupId}/posts")
-	public ResponseEntity<GetPostGroupPostsResponse> getPostsByPostGroup(
-		@PathVariable Long agentId,
-		@PathVariable Long postGroupId
-	) {
-		return ResponseEntity.ok(postService.getPostsByPostGroup(agentId, postGroupId));
-	}
-
-	@Operation(summary = "게시물 프롬프트 내역 조회 API", description = "게시물 결과 수정 단계에서 프롬프트 내역을 조회합니다.")
-	@GetMapping("/{postGroupId}/posts/{postId}/prompt-histories")
-	public ResponseEntity<List<PromptHistoriesResponse>> getPromptHistories(
-		@PathVariable Long agentId,
-		@PathVariable Long postGroupId,
-		@PathVariable Long postId
-	) {
-		return ResponseEntity.ok(postPromptHistoryService.getPromptHistories(agentId, postGroupId, postId));
-	}
-
 	@Operation(
 		summary = "게시물 내용 수정 API",
 		description = """
@@ -210,6 +185,43 @@ public class PostController {
 	) {
 		postService.deletePosts(agentId, postGroupId, postIds);
 		return ResponseEntity.noContent().build();
+	}
+
+	@Operation(summary = "계정별 게시물 그룹 목록 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹 목록을 조회합니다.")
+	@GetMapping
+	public ResponseEntity<GetPostGroupsResponse> getPostGroupsByAgent(@PathVariable Long agentId) {
+		return ResponseEntity.ok(postService.getPostGroups(agentId));
+	}
+
+	@Operation(summary = "게시물 그룹 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹을 단건 조회합니다.")
+	@GetMapping("/{postGroupId}")
+	public ResponseEntity<Void> getPostGroup(@PathVariable Long agentId, @PathVariable Long postGroupId) {
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "게시물 그룹 주제 조회 API", description = "화면 헤더 Breadcrumb에 표시할 게시물 그룹 주제를 조회합니다.")
+	@GetMapping("/{postGroupId}/topic")
+	public ResponseEntity<Void> getPostGroupTopic(@PathVariable Long agentId, @PathVariable Long postGroupId) {
+		return ResponseEntity.ok().build();
+	}
+
+	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")
+	@GetMapping("/{postGroupId}/posts")
+	public ResponseEntity<GetPostGroupPostsResponse> getPostsByPostGroup(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId
+	) {
+		return ResponseEntity.ok(postService.getPostsByPostGroup(agentId, postGroupId));
+	}
+
+	@Operation(summary = "게시물 프롬프트 내역 조회 API", description = "게시물 결과 수정 단계에서 프롬프트 내역을 조회합니다.")
+	@GetMapping("/{postGroupId}/posts/{postId}/prompt-histories")
+	public ResponseEntity<List<PromptHistoriesResponse>> getPromptHistories(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId,
+		@PathVariable Long postId
+	) {
+		return ResponseEntity.ok(postPromptHistoryService.getPromptHistories(agentId, postGroupId, postId));
 	}
 
 	@Operation(

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -10,8 +10,10 @@ import org.mainapp.domain.post.controller.request.UpdatePostsMetadataRequest;
 import org.mainapp.domain.post.controller.response.CreatePostsResponse;
 import org.mainapp.domain.post.controller.response.GetAgentReservedPostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupPostsResponse;
+import org.mainapp.domain.post.controller.response.GetPostGroupTopicResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupsResponse;
 import org.mainapp.domain.post.controller.response.PromptHistoriesResponse;
+import org.mainapp.domain.post.controller.response.type.PostGroupResponse;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
 import org.mainapp.domain.post.service.PostPromptHistoryService;
 import org.mainapp.domain.post.service.PostService;
@@ -195,14 +197,17 @@ public class PostController {
 
 	@Operation(summary = "게시물 그룹 조회 API", description = "사용자가 연동한 SNS 계정 내의 게시물 그룹을 단건 조회합니다.")
 	@GetMapping("/{postGroupId}")
-	public ResponseEntity<Void> getPostGroup(@PathVariable Long agentId, @PathVariable Long postGroupId) {
-		return ResponseEntity.ok().build();
+	public ResponseEntity<PostGroupResponse> getPostGroup(@PathVariable Long agentId, @PathVariable Long postGroupId) {
+		return ResponseEntity.ok(postService.getPostGroup(agentId, postGroupId));
 	}
 
 	@Operation(summary = "게시물 그룹 주제 조회 API", description = "화면 헤더 Breadcrumb에 표시할 게시물 그룹 주제를 조회합니다.")
 	@GetMapping("/{postGroupId}/topic")
-	public ResponseEntity<Void> getPostGroupTopic(@PathVariable Long agentId, @PathVariable Long postGroupId) {
-		return ResponseEntity.ok().build();
+	public ResponseEntity<GetPostGroupTopicResponse> getPostGroupTopic(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId
+	) {
+		return ResponseEntity.ok(postService.getPostGroupTopic(agentId, postGroupId));
 	}
 
 	@Operation(summary = "게시물 그룹별 게시물 목록 조회 API", description = "게시물 그룹에 해당되는 모든 게시물 목록을 조회합니다.")

--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetPostGroupTopicResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/response/GetPostGroupTopicResponse.java
@@ -1,0 +1,16 @@
+package org.mainapp.domain.post.controller.response;
+
+import org.domainmodule.postgroup.entity.PostGroup;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "게시물 그룹 주제 조회 API 응답 본문")
+public record GetPostGroupTopicResponse(
+	@Schema(description = "게시물 그룹 주제", example = "햄부기 먹기")
+	String topic
+) {
+
+	public static GetPostGroupTopicResponse from(PostGroup postGroup) {
+		return new GetPostGroupTopicResponse(postGroup.getTopic());
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -26,7 +26,9 @@ import org.mainapp.domain.post.controller.request.type.UpdatePostsRequestItem;
 import org.mainapp.domain.post.controller.response.CreatePostsResponse;
 import org.mainapp.domain.post.controller.response.GetAgentReservedPostsResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupPostsResponse;
+import org.mainapp.domain.post.controller.response.GetPostGroupTopicResponse;
 import org.mainapp.domain.post.controller.response.GetPostGroupsResponse;
+import org.mainapp.domain.post.controller.response.type.PostGroupResponse;
 import org.mainapp.domain.post.controller.response.type.PostResponse;
 import org.mainapp.domain.post.exception.PostErrorCode;
 import org.mainapp.global.constants.PostGenerationCount;
@@ -108,6 +110,26 @@ public class PostService {
 
 		// 반환
 		return GetPostGroupsResponse.from(postGroups);
+	}
+
+	/**
+	 * 게시물 그룹을 단건 조회하는 메서드
+	 */
+	public PostGroupResponse getPostGroup(Long agentId, Long postGroupId) {
+		Long userId = SecurityUtil.getCurrentUserId();
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
+		return PostGroupResponse.from(postGroup);
+	}
+
+	/**
+	 * 게시물 그룹의 주제를 조회하는 메서드
+	 */
+	public GetPostGroupTopicResponse getPostGroupTopic(Long agentId, Long postGroupId) {
+		Long userId = SecurityUtil.getCurrentUserId();
+		String topic = postGroupRepository.findTopicByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
+		return new GetPostGroupTopicResponse(topic);
 	}
 
 	/**
@@ -292,7 +314,8 @@ public class PostService {
 	 */
 	public GetAgentReservedPostsResponse getAgentReservedPosts(Long agentId) {
 		Long userId = SecurityUtil.getCurrentUserId();
-		List<Post> posts = postRepository.findAllReservedPostsByUserAndAgent(userId, agentId, PostStatusType.UPLOAD_RESERVED);
+		List<Post> posts = postRepository.findAllReservedPostsByUserAndAgent(userId, agentId,
+			PostStatusType.UPLOAD_RESERVED);
 
 		return GetAgentReservedPostsResponse.from(posts);
 	}

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
@@ -27,4 +27,12 @@ public interface PostGroupRepository extends JpaRepository<PostGroup, Long> {
 			and pg.id = :postGroupId
 		""")
 	Optional<PostGroup> findByUserIdAndAgentIdAndId(Long userId, Long agentId, Long postGroupId);
+
+	@Query("""
+			select pg.topic from PostGroup pg
+			where pg.agent.user.id = :userId
+			and pg.agent.id = :agentId
+			and pg.id = :postGroupId
+		""")
+	Optional<String> findTopicByUserIdAndAgentIdAndId(Long userId, Long agentId, Long postGroupId);
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #201 

## 📌 작업 내용 및 특이사항

### 1. 게시물 그룹 조회 API 구현
당장 필요한 API는 아니지만, 프론트에서 필요한 경우 유연하게 사용할 수 있도록 구현해두었습니다.

### 2. 게시물 그룹 주제 조회 API 구현
화면 헤더의 Breadcrumb에 표시될 게시물 그룹 주제를 조회하기 위한 API입니다.
이때 불필요한 쿼리가 발생하지 않도록 다음과 같이 topic 컬럼만 조회하는 쿼리를 따로 작성했습니다.
```java
public interface PostGroupRepository extends JpaRepository<PostGroup, Long> {

  @Query("""
      select pg.topic from PostGroup pg
      where pg.agent.user.id = :userId
      and pg.agent.id = :agentId
      and pg.id = :postGroupId
    """)
  Optional<String> findTopicByUserIdAndAgentIdAndId(Long userId, Long agentId, Long postGroupId);
}
```