### PR TITLE
[#207] refactor: Twitter 로그인은 Jwt필터 거치도록 설정

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
@@ -12,8 +12,7 @@ public final class WebSecurityURI {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/swagger-resources/**",
-		"/common/health/**",
-		"/twitter/**"
+		"/common/health/**"
 	);
 
 	public static final List<String> CORS_ALLOW_URIS =


### PR DESCRIPTION
## 🌱 관련 이슈
- close #207 

## 📌 작업 내용 및 특이사항
- 트위터 로그인 후 SecurityContext에 정보가 없어서 userId를 찾을 수 없는 문제점이 있었음
- Jwt필터를 거치도록 설정해서 문제해결했습니다~

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


