### PR TITLE
[#202] Refactor: Agent엔티티 accountName필드 추가

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/controller/response/type/AgentResponse.java
@@ -16,7 +16,9 @@ public record AgentResponse(
 	LocalDateTime createdAt,
 	@Schema(description = "SNS 종류", example = "X")
 	AgentPlatformType platform,
-	@Schema(description = "SNS 계정 id (외부 SNS 내)", example = "1")
+	@Schema(description = "SNS 계정 이름 (사용자가 입력한 ID)", example = "test123")
+	String accountName,
+	@Schema(description = "SNS 고유 id (Sns 계정 식별을 위한 값)", example = "1342312")
 	String accountId,
 	@Schema(description = "계정 한줄소개", example = "최신 AI 소식을 전해드려요!")
 	String bio,
@@ -33,6 +35,7 @@ public record AgentResponse(
 			agent.getId(),
 			agent.getCreatedAt(),
 			agent.getPlatform(),
+			agent.getAccountName(),
 			agent.getAccountId(),
 			agent.getBio(),
 			agent.getProfileImage(),

--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -53,7 +53,8 @@ public class AgentService {
 			userInfo.id(),
 			userInfo.description(),
 			userInfo.profileImageUrl(),
-			userInfo.subscriptionType()
+			userInfo.subscriptionType(),
+			userInfo.username()
 		);
 		AgentPersonalSetting newAgentPersonalSetting = AgentPersonalSetting.create(
 			newAgent, "", "", AgentToneType.LESS_FORMAL, "");
@@ -61,7 +62,7 @@ public class AgentService {
 	}
 
 	private Agent updatAgent(Agent agent, TwitterUserInfoDto userInfo) {
-		agent.updateInfo(userInfo.description(), userInfo.profileImageUrl(), userInfo.subscriptionType());
+		agent.updateInfo(userInfo.description(), userInfo.profileImageUrl(), userInfo.subscriptionType(), userInfo.username());
 		return agentTransactionService.saveAgent(agent);
 	}
 

--- a/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
@@ -12,8 +12,7 @@ public final class WebSecurityURI {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/swagger-resources/**",
-		"/common/health/**",
-		"/twitter/**"
+		"/common/health/**"
 	);
 
 	public static final List<String> CORS_ALLOW_URIS =

--- a/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/agent/entity/Agent.java
@@ -43,6 +43,9 @@ public class Agent extends BaseTimeEntity {
 	@Column(nullable = false, unique = true, length = 100)
 	private String accountId;
 
+	@Column(length = 200)
+	private String accountName;
+
 	@Column(length = 255)
 	private String bio;
 
@@ -70,6 +73,7 @@ public class Agent extends BaseTimeEntity {
 		String accountId,
 		String bio,
 		String profileImage,
+		String accountName,
 		AgentPlanType agentPlan
 	) {
 		this.user = user;
@@ -77,6 +81,7 @@ public class Agent extends BaseTimeEntity {
 		this.accountId = accountId;
 		this.bio = bio;
 		this.profileImage = profileImage;
+		this.accountName = accountName;
 		this.autoMode = Boolean.FALSE;
 		this.agentPlan = agentPlan;
 		this.isActivated = Boolean.TRUE;
@@ -88,7 +93,8 @@ public class Agent extends BaseTimeEntity {
 		String accountId,
 		String bio,
 		String profileImage,
-		String subscriptionType
+		String subscriptionType,
+		String accountName
 	) {
 		return Agent.builder()
 			.user(user)
@@ -97,17 +103,20 @@ public class Agent extends BaseTimeEntity {
 			.bio(bio)
 			.profileImage(profileImage)
 			.agentPlan(AgentPlanType.fromSubscription(subscriptionType))
+			.accountName(accountName)
 			.build();
 	}
 
 	public void updateInfo(
 		String bio,
 		String profileImage,
-		String agentType
+		String agentType,
+		String accountName
 
 	) {
 		this.bio = bio;
 		this.profileImage = profileImage;
 		this.agentPlan = AgentPlanType.fromSubscription(agentType);
+		this.accountName = accountName;
 	}
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #202 

## 📌 작업 내용 및 특이사항
- Sns 사용자의 계정 ID를 받아오는 필드로 accountName 추가
- accountId 는 Sns계정의 고유 ID값 (Sns 계정 추가 시 존재여부 체크를 위해 필요)
- accountName은 사용자의 계정 ID

## 🧐 고민한 점
- Agent 엔티티가 변경되어서 배포후에 mysql을 업데이트해야할 것. 같아요

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


