### PR TITLE
[#211] Feature: PostGroup 삭제 API

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/controller/PostController.java
@@ -219,6 +219,16 @@ public class PostController {
 		return ResponseEntity.ok(postService.getPostsByPostGroup(agentId, postGroupId));
 	}
 
+	@Operation(summary = "게시물 그룹 제거 API", description = "게시물 그룹에 해당되는 모든 게시물들을 삭제합니다.")
+	@DeleteMapping("/{postGroupId}")
+	public ResponseEntity<Void> deletePostGroup(
+		@PathVariable Long agentId,
+		@PathVariable Long postGroupId
+	) {
+		postService.deletePostGroup(agentId, postGroupId);
+		return ResponseEntity.noContent().build();
+	}
+
 	@Operation(summary = "게시물 프롬프트 내역 조회 API", description = "게시물 결과 수정 단계에서 프롬프트 내역을 조회합니다.")
 	@GetMapping("/{postGroupId}/posts/{postId}/prompt-histories")
 	public ResponseEntity<List<PromptHistoriesResponse>> getPromptHistories(

--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -35,6 +35,7 @@ import org.mainapp.global.constants.PostGenerationCount;
 import org.mainapp.global.error.CustomException;
 import org.mainapp.global.util.SecurityUtil;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
@@ -332,5 +333,19 @@ public class PostService {
 		Post post = postRepository.findByPostGroupAndId(postGroup, postId)
 			.orElseThrow(() -> new CustomException(PostErrorCode.POST_NOT_FOUND));
 		return PostResponse.from(post);
+	}
+
+	/**
+	 * PostGroup 삭제 - Group에 속한 모든 Post 제거
+	 */
+	@Transactional
+	public void deletePostGroup(Long agentId, Long postGroupId) {
+		Long userId = SecurityUtil.getCurrentUserId();
+		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
+			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
+		List<Post> posts = postRepository.findAllByPostGroup(postGroup);
+
+		postRepository.deleteAll(posts);
+		postGroupRepository.delete(postGroup);
 	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/entity/PostGroup.java
@@ -10,6 +10,7 @@ import org.domainmodule.postgroup.entity.type.PostGroupPurposeType;
 import org.domainmodule.postgroup.entity.type.PostGroupReferenceType;
 import org.domainmodule.rssfeed.entity.RssFeed;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -21,6 +22,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,9 +57,6 @@ public class PostGroup extends BaseTimeEntity {
 	@JoinColumn(name = "feed_id")
 	private RssFeed feed;
 
-	@OneToMany(mappedBy = "postGroup")
-	private List<PostGroupImage> postGroupImages = new ArrayList<>();
-
 	@Enumerated(EnumType.STRING)
 	private PostGroupLengthType length;
 
@@ -67,6 +66,12 @@ public class PostGroup extends BaseTimeEntity {
 	private Integer generationCount;
 
 	private String thumbnailImage;
+
+	@OneToMany(mappedBy = "postGroup", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	private List<PostGroupImage> postGroupImages = new ArrayList<>();
+
+	@OneToOne(mappedBy = "postGroup", cascade = CascadeType.REMOVE, orphanRemoval = true)
+	private PostGroupRssCursor postGroupRssCursor;
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private PostGroup(


### PR DESCRIPTION
## 🌱 관련 이슈
- close #211

## 📌 작업 내용 및 특이사항
- PostGroup 삭제 요청 시 관련된 데이터 삭제

- PostGroup의 연관 엔티티 (PostGroupImage, PostGroupRssCursor) 제거
**PostGroup 엔티티**
```java
@OneToMany(mappedBy = "postGroup", cascade = CascadeType.REMOVE, orphanRemoval = true)
	private List<PostGroupImage> postGroupImages = new ArrayList<>();

	@OneToOne(mappedBy = "postGroup", cascade = CascadeType.REMOVE, orphanRemoval = true)
	private PostGroupRssCursor postGroupRssCursor;
```

- Post와 연관된 엔티티 (PostImage, PromptHistory) 제거 
**Post엔티티**
```java
	@OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
	private List<PostImage> postImages = new ArrayList<>();

	@OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
	private List<PromptHistory> promptHistories = new ArrayList<>();
```
**PostService.java**
```java
public void deletePostGroup(Long agentId, Long postGroupId) {
		Long userId = SecurityUtil.getCurrentUserId();
		PostGroup postGroup = postGroupRepository.findByUserIdAndAgentIdAndId(userId, agentId, postGroupId)
			.orElseThrow(() -> new CustomException(PostErrorCode.POST_GROUP_NOT_FOUND));
		List<Post> posts = postRepository.findAllByPostGroup(postGroup);

		postRepository.deleteAll(posts);
		postGroupRepository.delete(postGroup);
	}
```
cascade 설정으로 Posts를 제거하면 관련된 promptHistories,postImages 제거
cascade 설정으로 PostGroup을 제거하면 관련된 postGroupRssCursor, postGroupImages 제거

## 🧐 고민한 점
-  Post와 PostGroup으로 각각 분리를 해서 제거하는 방식으로 진행했어요.
- cascade설정을 전부 걸게 되면 PostGroup만을 제거해도 관련된 모든 엔티티를 제거할 수 있지만, 큰 범위로 잘라서 제거해야 흐름이 보인다고 생각해서 이렇게 했습니다!

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


