### PR TITLE
[#222] Refactor: twitter 리다이렉트시 cors문제 해결

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/agent/service/AgentService.java
@@ -35,10 +35,9 @@ public class AgentService {
 	 * X API 로그인을 성공한 후 Agent와 SnsToken 생성 및 저장
 	 * @return 생성된 Agent 엔티티
 	 */
-	public Agent updateOrCreateAgent(TwitterUserInfoDto userInfo) {
+	public Agent updateOrCreateAgent(TwitterUserInfoDto userInfo, String userId) {
 		// 사용자 인증 정보 조회
-		Long userId = SecurityUtil.getCurrentUserId();
-		User user = userService.findUserById(userId);
+		User user = userService.findUserById(Long.parseLong(userId));
 
 		// Agent가 이미 존재하는지 확인
 		return agentRepository.findByAccountIdAndPlatform(userInfo.id(), AgentPlatformType.X)

--- a/application/main-app/src/main/java/org/mainapp/domain/sns/twitter/TwitterController.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/sns/twitter/TwitterController.java
@@ -2,8 +2,10 @@ package org.mainapp.domain.sns.twitter;
 
 import java.io.IOException;
 
+import org.mainapp.domain.sns.twitter.response.TwitterRedirectResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,18 +23,22 @@ public class TwitterController {
 
 	private final TwitterService twitterService;
 
-	@Operation(summary = "X(Twitter) 계정 연결 API", description = "X(Twitter) 계정 연결을 위해 OAuth2 로그인 페이지로 이동하는 API입니다.")
+	@Operation(summary = "X(Twitter) 계정 연결 API", description = "X(Twitter) 계정 연결을 위해 OAuth2 로그인 페이지로 이동하는 Url을 반환")
 	@GetMapping("/login")
-	public ResponseEntity<Void> redirectToTwitterAuth() {
-		return twitterService.createRedirectResponse();
+	public ResponseEntity<TwitterRedirectResponse> redirectToTwitterAuth(
+		@RequestHeader("Authorization") String accessToken
+	) {
+		String url = twitterService.createRedirectResponse(accessToken);
+		return ResponseEntity.ok(TwitterRedirectResponse.from(url));
 	}
 
 	@GetMapping("/success")
 	public void handleTwitterLoginCallback(
 		@RequestParam String code,
+		@RequestParam String state,
 		HttpServletResponse response
 	) throws IOException {
-		String redirectUrl = twitterService.loginOrRegister(code);
+		String redirectUrl = twitterService.loginOrRegister(code, state);
 		response.sendRedirect(redirectUrl);
 	}
 }

--- a/application/main-app/src/main/java/org/mainapp/domain/sns/twitter/response/TwitterRedirectResponse.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/sns/twitter/response/TwitterRedirectResponse.java
@@ -1,0 +1,9 @@
+package org.mainapp.domain.sns.twitter.response;
+
+public record TwitterRedirectResponse(
+	String redirectUrl
+) {
+	public static TwitterRedirectResponse from(String redirectUrl) {
+		return new TwitterRedirectResponse(redirectUrl);
+	}
+}

--- a/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
+++ b/application/main-app/src/main/java/org/mainapp/global/constants/WebSecurityURI.java
@@ -12,7 +12,8 @@ public final class WebSecurityURI {
 		"/swagger-ui/**",
 		"/v3/api-docs/**",
 		"/swagger-resources/**",
-		"/common/health/**"
+		"/common/health/**",
+		"/twitter/success/**"
 	);
 
 	public static final List<String> CORS_ALLOW_URIS =

--- a/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterApiService.java
+++ b/clients/sns-client/src/main/java/org/snsclient/twitter/service/TwitterApiService.java
@@ -16,12 +16,15 @@ public class TwitterApiService {
 	private final TwitterMediaUploadService twitterMediaUploadService;
 	private final Twitter4jService twitter4jService;
 
-
 	/**
 	 * authorization url 생성 메서드
 	 */
-	public String getTwitterAuthorizationUrl() {
-		return twitter4jService.getTwitterAuthorizationUrl();
+	public String getTwitterAuthorizationUrl(String userId) {
+		String url = twitter4jService.getTwitterAuthorizationUrl();
+		//TODO userID를 트위터 로그인 같이 감아보내는데 Base64인코딩해서 암호화하기
+
+		// 기존 state 값을 교체하여 하나만 유지
+		return url.replaceAll("&state=[^&]*", "") + "&state=" + userId;
 	}
 
 	/**


### PR DESCRIPTION
## 🌱 관련 이슈
- close #222 

## 📌 작업 내용 및 특이사항
- 트위터 리다이렉트시 cors문제 해결

[트위터 로그인시 로그인한 userId를 가져올 수 없는 문제 발생]
- stateless한 특징 때문에 기존에 google로 로그인한 userId를 가져올 수 없어 트위치 계정과 연결시킬 수 없는 문제가 있었습니다
- Twitter에서는 로그인을 하기 위해서는 웹에서만 요청가능(API 호출 시 제한) 
[해결방안]
- twitter/login 요청시 헤더의 토큰을 가져와 userId 파싱진행
- redirect url을 클라이언트에게 전송( 이때 state값에 userId를 같이 전송)
- 클라이언트에서 x로그인 페이지로 진입
- twitter/success로 리다이렉트가 들어오면 url에서 userId를 가져옴
- userId로 해당 유저가 twitter를 새로등록한다면 USer-Twitter 을 연동, 기존에 등록된 tiwtter이라면 twitter 정보만 업데이트

## 🧐 고민한 점
- 

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


