### PR TITLE
[#226] Feature: RSS 피드 페이징 방식 변경

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostCreateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostCreateService.java
@@ -434,7 +434,8 @@ public class PostCreateService {
 		String topicPrompt = createPostPromptTemplate.getTopicPrompt(
 			vo.topic(), vo.purpose(), vo.length(), vo.content());
 		List<String> refPrompts = feedPagingResult.getFeedItems().stream()
-			.map(news -> createPostPromptTemplate.getNewsRefPrompt(news.getContentSummary(), news.getContent()))
+			.map(news ->
+				createPostPromptTemplate.getNewsRefPrompt(news.getTitle(), news.getContentSummary(), news.getContent()))
 			.toList();
 
 		// 게시물 생성하기: 각 뉴스 기사별로 OpenAI API 호출 및 답변 생성

--- a/application/main-app/src/main/java/org/mainapp/openai/prompt/CreatePostPromptTemplate.java
+++ b/application/main-app/src/main/java/org/mainapp/openai/prompt/CreatePostPromptTemplate.java
@@ -68,8 +68,9 @@ public class CreatePostPromptTemplate {
 	 * 게시물 그룹에 설정된 참고자료 Prompt.
 	 * "뉴스를 참고하는" 게시물 그룹을 위해 뉴스에 대한 참고자료 Prompt를 생성
 	 */
-	public String getNewsRefPrompt(String summary, String content) {
+	public String getNewsRefPrompt(String title, String summary, String content) {
 		return "다음 뉴스 기사 내용을 바탕으로 게시물을 생성해줘:\n"
+			+ "제목: " + title + "\n"
 			+ "요약: " + summary + "\n"
 			+ "본문: " + content;
 	}

--- a/clients/feed-client/src/test/java/org/feedclient/service/FeedServiceImplTest.java
+++ b/clients/feed-client/src/test/java/org/feedclient/service/FeedServiceImplTest.java
@@ -19,7 +19,7 @@ class FeedServiceImplTest {
 	@Test
 	void getPagedFeedTest() {
 		// Given
-		String feedUrl = "https://rss.app/feeds/v1.1/t3OECiAGSXYOG8h5.json";
+		String feedUrl = "https://rss.app/feeds/v1.1/zHvdVTrJSiWM5qfm.json";
 
 		// When
 		FeedPagingResult newsFeed = feedService.getPagedFeed(feedUrl, 5);
@@ -42,10 +42,10 @@ class FeedServiceImplTest {
 	@Test
 	void getPagedFeedByCursorTest() {
 		// Given
-		String feedUrl = "https://rss.app/feeds/v1.1/t3OECiAGSXYOG8h5.json";
+		String feedUrl = "https://rss.app/feeds/v1.1/zHvdVTrJSiWM5qfm.json";
 
 		// When
-		FeedPagingResult newsFeed = feedService.getPagedFeed(feedUrl, "448f82132b9b63e67fb8e5aba1987317", 5);
+		FeedPagingResult newsFeed = feedService.getPagedFeed(feedUrl, "bcc71628d40e410be723c65dc9af409e", 5);
 		for (FeedItem feedItem : newsFeed.getFeedItems()) {
 			System.out.println(feedItem.getId() + ": " + feedItem.getTitle());
 			System.out.println(feedItem.getDatePublished());


### PR DESCRIPTION
## 🌱 관련 이슈
- close #226 

## 📌 작업 내용 및 특이사항
RSS 피드를 기존 rss.app 자체에서 제공하는 피드에서 네이버 뉴스를 파싱하는 피드로 변경하게 되었는데요, 이때 네이버 뉴스 페이지에서 datePublished 필드를 파싱하지 못해서 피드 내의 모든 datePublished 필드가 당일 00시 00분으로 통일되는 문제가 있었습니다.

기존에 RSS 피드를 페이징하는 방식은 datePublished 필드를 기준으로 오름차순 정렬을 수행하게 되어 있었기 때문에, 현재의 경우 의도한대로 페이징이 동작하지 않을 수 있다고 판단했어요.

따라서 이를 해결하기 위해 페이징을 위해 따로 정렬하지 않고, rss 피드 자체 정렬 순서를 유지하는 방식으로 변경했습니다. 기본적으로 RSS 피드는 최신 뉴스일수록 상단에 위치하기 때문에 기본 정렬이 작성일 내림차순 정렬이 유지되더라구요. 네이버 뉴스 페이지를 파싱하는 경우에도 마찬가지였어서, 기존 피드에 대한 동작 방식도 그대로 유지되는 점 확인했습니다!

## 📚 기타
- 뉴스 카테고리 타입 자체는 아직 변경하지 않았습니다! 이후 팀원분들과 상의해서 뉴스 카테고리 정한 후에 변경하도록 할게요