### PR TITLE
[#243] Feature: 게시물 그룹 목록 조회 시 최신순 정렬하도록 변경

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostService.java
@@ -105,9 +105,9 @@ public class PostService {
 	 * 사용자 연동 SNS 계정별 게시물 그룹 목록을 반환하는 메서드
 	 */
 	public GetPostGroupsResponse getPostGroups(Long agentId) {
-		// 사용자 인증 정보 및 PostGroup 리스트 조회
+		// 사용자 인증 정보 및 PostGroup 리스트 최신순 조회
 		Long userId = SecurityUtil.getCurrentUserId();
-		List<PostGroup> postGroups = postGroupRepository.findAllByUserIdAndAgentId(userId, agentId);
+		List<PostGroup> postGroups = postGroupRepository.findAllByUserIdAndAgentIdOrderByLatest(userId, agentId);
 
 		// 반환
 		return GetPostGroupsResponse.from(postGroups);

--- a/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/postgroup/repository/PostGroupRepository.java
@@ -24,6 +24,16 @@ public interface PostGroupRepository extends JpaRepository<PostGroup, Long> {
 			join fetch pg.agent.user
 			where pg.agent.user.id = :userId
 			and pg.agent.id = :agentId
+			order by pg.id desc
+		""")
+	List<PostGroup> findAllByUserIdAndAgentIdOrderByLatest(Long userId, Long agentId);
+
+	@Query("""
+			select pg from PostGroup pg
+			join fetch pg.agent
+			join fetch pg.agent.user
+			where pg.agent.user.id = :userId
+			and pg.agent.id = :agentId
 			and pg.id = :postGroupId
 		""")
 	Optional<PostGroup> findByUserIdAndAgentIdAndId(Long userId, Long agentId, Long postGroupId);


### PR DESCRIPTION
## 🌱 관련 이슈
- close #243 

## 📌 작업 내용 및 특이사항
홈 화면에서 계정별 게시물 그룹 목록을 최신순으로 정렬해 조회하도록 변경했습니다.