### PR TITLE
[#259] Refactor: displayOrder가 변경되어도 updatedAt 갱신안되도록 수정

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/domain/post/service/PostUpdateService.java
+++ b/application/main-app/src/main/java/org/mainapp/domain/post/service/PostUpdateService.java
@@ -88,6 +88,8 @@ public class PostUpdateService {
 				if (postRequest.getDisplayOrder() != null) {
 					post.updateDisplayOrder(postRequest.getDisplayOrder());
 				}
+				post.markPreventUpdatedAt(); // updateAt 갱신 방지
+
 			});
 
 		// 수정 내용 저장

--- a/domain/domain-module/src/main/java/org/domainmodule/common/entity/BaseAuditEntity.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/common/entity/BaseAuditEntity.java
@@ -2,12 +2,13 @@ package org.domainmodule.common.entity;
 
 import java.time.LocalDateTime;
 
-import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Transient;
 import lombok.Getter;
 
 @MappedSuperclass
@@ -15,7 +16,25 @@ import lombok.Getter;
 @Getter
 public class BaseAuditEntity extends BaseTimeEntity {
 
-	@LastModifiedDate
 	@Column(updatable = true, nullable = false)
 	private LocalDateTime updatedAt;
+
+	@Transient
+	private boolean preventUpdatedAt = false;
+
+	@PreUpdate
+	public void setPreventUpdatedAt() {
+		// 업데이트가 가능하면 현재시간으로 설정
+		if (!isPreventUpdatedAt()) {
+			this.updatedAt = LocalDateTime.now();
+		}
+	}
+
+	public void markPreventUpdatedAt() {
+		this.preventUpdatedAt = true;
+	}
+
+	private boolean isPreventUpdatedAt() {
+		return preventUpdatedAt;
+	}
 }

--- a/domain/domain-module/src/main/java/org/domainmodule/post/entity/Post.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/entity/Post.java
@@ -111,6 +111,7 @@ public class Post extends BaseAuditEntity {
 
 	public void updateDisplayOrder(Integer displayOrder) {
 		this.displayOrder = displayOrder;
+		this.markPreventUpdatedAt(); // updateAt 갱신 방지
 	}
 
 	public void updateContent(String content) {

--- a/domain/domain-module/src/main/java/org/domainmodule/post/entity/Post.java
+++ b/domain/domain-module/src/main/java/org/domainmodule/post/entity/Post.java
@@ -111,7 +111,6 @@ public class Post extends BaseAuditEntity {
 
 	public void updateDisplayOrder(Integer displayOrder) {
 		this.displayOrder = displayOrder;
-		this.markPreventUpdatedAt(); // updateAt 갱신 방지
 	}
 
 	public void updateContent(String content) {


### PR DESCRIPTION
## 🌱 관련 이슈
- close #259 

## 📌 작업 내용 및 특이사항
- [페이지 순서 변경 시 모든 게시물이 변경되는 오류](https://www.notion.so/yapp-workspace/1a02106a0e8480fb9bd6f77c148b66d1?pvs=4) 이 이슈에 대해서 작업했습니다
- Post의 displayOrder가 변경이 되면 프론트에서 [1분전] 처럼 표시되는 부분이 전부 업데이트가 되는 방식에서
- displayOrder가 변경이 되더라도 UpdatedAt이 갱신이 되지 않도록 코드를 수정했습니닷
- 결론적으로, post의 내용수정에만 updateAt이 갱신이 되도록 했어요.

```java
public class BaseAuditEntity extends BaseTimeEntity {

         // 기존의 @LastModified가 제거되고 아래의 LocalDateTime.now()로 직접 주입

	@Column(updatable = true, nullable = false)
	private LocalDateTime updatedAt;

	@Transient
	private boolean preventUpdatedAt = false;

	@PreUpdate
	public void setPreventUpdatedAt() {
		// 업데이트가 가능하면 현재시간으로 설정
		if (!isPreventUpdatedAt()) {
			this.updatedAt = LocalDateTime.now();
		}
	}

       // preventUpdateAt이 true일 경우에는 updateAt을 갱신하지 않음
	public void markPreventUpdatedAt() {
		this.preventUpdatedAt = true;
	}
       
	private boolean isPreventUpdatedAt() {
		return preventUpdatedAt;
	}
}
```
## 🧐 고민한 점
-  순서변경에는 updatedAt이 변경이 되지 않도록 하는게 맞는 방향인지 고민을 해봐야할 것 같아요

## 🚀 리뷰 해줬으면 하는 부분
- 

## 📚 기타 / 관련 문서
- 


