### PR TITLE
[#273] Fix: OpenAiClient에 타임아웃 설정

### DIFF
--- a/clients/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
+++ b/clients/open-ai-client/src/main/java/org/openaiclient/client/OpenAiClient.java
@@ -1,10 +1,12 @@
 package org.openaiclient.client;
 
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 
 import org.openaiclient.client.dto.request.ChatCompletionRequest;
 import org.openaiclient.client.dto.response.ChatCompletionResponse;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -19,7 +21,11 @@ public class OpenAiClient {
 		@Value("${client.openai.url}") String url,
 		@Value("${client.openai.key}") String key
 	) {
+		SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+		requestFactory.setConnectTimeout(Duration.ofSeconds(5));
+		requestFactory.setReadTimeout(Duration.ofSeconds(30));
 		this.openAiClient = RestClient.builder()
+			.requestFactory(requestFactory)
 			.baseUrl(url)
 			.defaultHeader("Authorization", "Bearer " + key)
 			.defaultHeader("Content-Type", "application/json")


### PR DESCRIPTION
## 🌱 관련 이슈
- close #273 

## 📌 작업 내용 및 특이사항
응답이 10초 이상 길어지는 경우 타임아웃이 발생하는 문제를 해결하기 위해, 타임아웃을 30초로 설정했습니다.
