### PR TITLE
[#283] Docs: 게시물 세부 주제 생성 프롬프트 변경

### DIFF
--- a/application/main-app/src/main/java/org/mainapp/openai/prompt/CreateDetailTopicsPromptTemplate.java
+++ b/application/main-app/src/main/java/org/mainapp/openai/prompt/CreateDetailTopicsPromptTemplate.java
@@ -17,7 +17,7 @@ public class CreateDetailTopicsPromptTemplate {
 		}
 
 		List<String> existTopicsPrompt = existTopics.stream()
-			.map(existTopic -> "- " + existTopic + "\n")
+			.map(existTopic -> existTopic + "\n")
 			.toList();
 
 		return "세부 주제를 추천할 때, 다음 주제를과 겹치지 않는 내용으로 추천해줘.\n" + existTopicsPrompt;


### PR DESCRIPTION
## 🌱 관련 이슈
- close #283 

## 📌 작업 내용 및 특이사항
기존 게시물 세부 주제 생성 프롬프트에서, 제외할 세부 주제를 입력할 때 "-" 문자로 구분하게 입력했더니 생성되는 세부 주제에도 "-" 문자가 붙은 채로 생성되는 경우가 있었습니다. 이 부분을 해결하기 위해 프롬프트에서 해당 부분을 제거했습니다.